### PR TITLE
loadURL is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 atom/
+
+bin/node_modules/*

--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@
 # HXElectron
 
 Haxe externs for [electron](http://electron.atom.io/).
+
+
+
+# Get started with Haxe and Electron
+
+Spin up the Quick Start app to see Electron in action:
+
+```
+# Clone the Haxe Quick Start repository
+$ git clone https://github.com/fponticelli/hxelectron
+
+# Go into the repository
+$ cd hxelectron/bin/
+
+# Install the dependencies and run
+$ npm install && npm start
+```

--- a/README.md
+++ b/README.md
@@ -7,14 +7,23 @@ Haxe externs for [electron](http://electron.atom.io/).
 
 # Get started with Haxe and Electron
 
-Spin up the Quick Start app to see Electron in action:
+
+
+
+Spin up the Haxe Quick Start app to see Electron in action:
 
 ```
 # Clone the Haxe Quick Start repository
 $ git clone https://github.com/fponticelli/hxelectron
 
 # Go into the repository
-$ cd hxelectron/bin/
+$ cd hxelectron/
+
+# Build JavaScript file with Haxe
+$ haxe build.hxml
+
+# Go into the repository
+$ cd bin/
 
 # Install the dependencies and run
 $ npm install && npm start

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,5 +1,11 @@
 {
-  "name"    : "your-app",
-  "version" : "0.1.0",
-  "main"    : "main.js"
+    "name"    : "your-app",
+    "version" : "0.1.0",
+    "main"    : "main.js",
+    "scripts": {
+          "start": "electron main.js"
+    },
+     "devDependencies": {
+        "electron-prebuilt": "^0.36.0"
+    }
 }

--- a/demo/Main.hx
+++ b/demo/Main.hx
@@ -18,7 +18,7 @@ class Main {
 		var mainWindow = null;
 		App.on( ready, function() {
 			mainWindow = new BrowserWindow({width: 800, height: 600});
-			mainWindow.loadUrl('file://' + Node.__dirname + '/index.html');
+			mainWindow.loadURL('file://' + Node.__dirname + '/index.html');
 			mainWindow.on( closed, function() {
 				mainWindow = null;
 			});

--- a/src/electron/main/BrowserWindow.hx
+++ b/src/electron/main/BrowserWindow.hx
@@ -84,7 +84,8 @@ extern class BrowserWindow extends EventEmitter<BrowserWindow> {
     function capturePage( ?rect : {x:Int,y:Int,width:Int,height:Int}, callback : NativeImage->Void ) : Void;
     function print( ?options : Dynamic ) : Void; //TODO
     function printToPDF( options : Dynamic, callback : Dynamic->Void ) : Void; //TODO
-    function loadUrl( url : String, ?options : Dynamic ) : Void;
+    // function loadUrl( url : String, ?options : Dynamic ) : Void;
+    function loadURL( url : String, ?options : Dynamic ) : Void;
     function reload() : Void;
     function setMenu( menu : Menu ) : Void;
     function setProgressBar( progress : Float ) : Void;

--- a/src/electron/main/WebContents.hx
+++ b/src/electron/main/WebContents.hx
@@ -65,6 +65,7 @@ import js.node.events.EventEmitter;
 extern class WebContents extends EventEmitter<WebContents> {
     var session(default,null) : Session;
     function loadUrl( url : String, ?options : {httpReferrer:String,userAgent:String} ) : Void;
+    // function loadURL( url : String, ?options : {httpReferrer:String,userAgent:String} ) : Void;
     function getUrl() : String;
     function getTitle() : String;
     function isLoading() : Bool;


### PR DESCRIPTION
- fixed: (electron) loadUrl is deprecated. Use loadURL instead.
- copied and  modified the Quick start instructions
- completed package.json
