### PR TITLE
Multitypes and rest args

### DIFF
--- a/tool/ElectronAPI.hx
+++ b/tool/ElectronAPI.hx
@@ -257,9 +257,8 @@ class ElectronAPI {
 			var result = null;
 			
 			for (item in _api) if (item.name == type) {
-				// Is there a cheaper way of getting the types fully qualified haxe name?
-				//result = //convertItem(item, ['electron']);
 				result = {name: item.name, pack: ['electron']};
+				
 				if( !item.process.main || !item.process.renderer ) {
 					if( item.process.main ) {
 						result.pack.push( 'main' );
@@ -299,7 +298,7 @@ class ElectronAPI {
 						
 					} else {
 						// Multiple types might be missing from the json file, we don't want
-						// to create haxe.extern.EitherType<Dynamic,Dynamic> ect.
+						// to create haxe.extern.EitherType<Dynamic,Dynamic> or worse ect.
 						for (type in types) switch type {
 							case TPath(c) if (c.name != 'Dynamic'):
 								types.push( macro:Dynamic );
@@ -356,9 +355,6 @@ class ElectronAPI {
 				
 			}
 			
-			//if (result != null) type = '__hx__multitype';
-			/*trace( types.map( haxe.macro.ComplexTypeTools.toString));
-			trace( haxe.macro.ComplexTypeTools.toString(result) );*/
 			result;
 			
 		} else {

--- a/tool/ElectronAPI.hx
+++ b/tool/ElectronAPI.hx
@@ -78,9 +78,9 @@ class ElectronAPI {
 	static var KWDS = ['class','switch'];
 
 	public static var pos(default,null) = #if macro null #else { min: 0, max: 0, file: '' } #end;
-
+	static var _api:Array<APIItem>;
 	public static function build( api : Array<APIItem>, ?pack : Array<String> ) : Array<TypeDefinition> {
-
+		_api = api;
 		if( pack == null ) pack = ['electron'];
 
 		var types = new Array<TypeDefinition>();
@@ -218,12 +218,24 @@ class ElectronAPI {
 			for( p in method.parameters ) {
 				//TODO temp hack
 				var type = untyped if( Std.is( p.type, Array ) ) 'Object' else p.type;
-				args.push( {
-					name: escapeName( p.name ),
-					type: convertType( type, p.properties ),
-					//TODO hack to check if field is optional
-					opt: p.description != null && p.description.startsWith( '(optional)')
-				} );
+				if (p.name == '...args') {
+					args.push( {
+						name: 'args',
+						type: macro:haxe.extern.Rest<Any>,
+						//TODO hack to check if field is optional
+						opt: p.description != null && p.description.startsWith( '(optional)')
+					} );
+					
+				} else {
+					args.push( {
+						name: escapeName( p.name ),
+						type: convertType( type, p.properties ),
+						//TODO hack to check if field is optional
+						opt: p.description != null && p.description.startsWith( '(optional)')
+					} );
+					
+				}
+				
 			}
 		}
 
@@ -236,11 +248,122 @@ class ElectronAPI {
 	}
 
 	static function convertType( type : String, ?properties : Array<Dynamic> ) : ComplexType {
-
+		inline function isKnownType(type:String):Bool {
+			var known = ['Bool','Boolean','Buffer','Int','Integer','Dynamic','Double','Float','Number','Function','Object','Promise','String','URL'];
+			return known.indexOf(type) > -1;
+		}
+		
+		inline function findMatch(type:String):Null<{name:String, pack:Array<String>}> {
+			var result = null;
+			
+			for (item in _api) if (item.name == type) {
+				// Is there a cheaper way of getting the types fully qualified haxe name?
+				//result = //convertItem(item, ['electron']);
+				result = {name: item.name, pack: ['electron']};
+				if( !item.process.main || !item.process.renderer ) {
+					if( item.process.main ) {
+						result.pack.push( 'main' );
+						
+					} else if( item.process.renderer ) {
+						result.pack.push( 'renderer' );
+						
+					}
+					
+				}
+				break;
+				
+			}
+			
+			return result;
+		}
+		
 		var isArray = if( type.endsWith( '[]' ) ) {
 			type = type.substr( 0, type.length-2 );
+			if (findMatch(type) == null && !isKnownType(type)) type = 'Dynamic';
 			true;
 		} else false;
+		
+		var multiType = if ( type.charAt(0) == '[' && type.charAt(type.length-1) == ']' ) {
+			var raw = type.substr(1, type.length-2).split(',');
+			var types = [];
+			
+			for (r in raw) {
+				var match = findMatch(r);
+				
+				if (match != null) {
+					types.push( TPath( { name: escapeTypeName(match.name), pack: match.pack } ) );
+					
+				} else {
+					if (isKnownType( r )) {
+						types.push( convertType( r ) );
+						
+					} else {
+						// Multiple types might be missing from the json file, we don't want
+						// to create haxe.extern.EitherType<Dynamic,Dynamic> ect.
+						for (type in types) switch type {
+							case TPath(c) if (c.name != 'Dynamic'):
+								types.push( macro:Dynamic );
+								break;
+								
+							case _:
+								trace( type );
+								
+						}
+						
+						if (types.length == 0) types.push( macro:Dynamic );
+						
+					}
+					
+				}
+				
+			}
+			
+			var result = null;
+			
+			if (types.length > 1) {
+				result = (macro:haxe.extern.EitherType);
+				var current = result;
+				
+				for (i in 0...types.length) {
+					var t = types[i];
+					
+					switch current {
+						case TPath(c):
+							if (c.params.length >= 1 && i < types.length-1) {
+								t = TPath( { name: 'EitherType', pack: ['haxe', 'extern'], params: [ TPType(t) ] } );
+								
+							}
+							
+							
+							
+						case _:
+							
+					}
+					
+					switch current {
+						case TPath(c):
+							c.params.push( TPType( t ) );
+							if (c.params.length >= 2) current = t;
+							
+						case _:
+							
+					}
+					
+				}
+				
+			} else {
+				result = types[0];
+				
+			}
+			
+			//if (result != null) type = '__hx__multitype';
+			/*trace( types.map( haxe.macro.ComplexTypeTools.toString));
+			trace( haxe.macro.ComplexTypeTools.toString(result) );*/
+			result;
+			
+		} else {
+			null;
+		}
 
 		var ctype = switch type {
 		case 'Bool','Boolean': macro : Bool;
@@ -262,7 +385,7 @@ class ElectronAPI {
 			if( properties == null ) macro : Dynamic else {
 				TAnonymous( [for(p in properties){
 					name: escapeName( p.name ),
-					kind: FVar( convertType( p.type, p.properties ) ),
+					kind: FVar( convertType( '' + p.type, p.properties ) ),
 					meta: [ { name: ":optional", pos: pos } ], //TODO
 					pos: pos,
 					doc: p.description
@@ -270,6 +393,7 @@ class ElectronAPI {
 			}
 		case 'Promise': macro : js.Promise<Dynamic>;
 		case 'String','URL': macro : String;
+		case _ if (multiType != null): multiType;
 		default: TPath( { pack: [], name: escapeTypeName( type ) } );
 		}
 
@@ -331,7 +455,7 @@ class ElectronAPI {
 		};
 	}
 
-	static function escapeTypeName( name : String ) : String
+	static function escapeTypeName( name : String ) : String 
 		return name.charAt( 0 ).toUpperCase() + name.substr( 1 );
 
 	static function escapeName( name : String ) : String


### PR DESCRIPTION
This adds support for multiple types using `haxe.extern.EitherType` and rest args that appear in `1.4.7` electron api file.

It appears to be in a working state. I'm in the process of converting a bunch of untyped electron scripts to use hxelectron, so hopefully I will pickup any compile errors as I go, but I assume @fponticelli and @tong probably have much large apps that you test against before updating :wink:.

Let me know if anything needs changing.