### PR TITLE
Fix a small bug in DesktopCapturer

### DIFF
--- a/electron-api.json
+++ b/electron-api.json
@@ -6038,7 +6038,7 @@
             "properties": [
               {
                 "name": "types",
-                "type": "String",
+                "type": "Array<String>",
                 "collection": true,
                 "description": "An array of Strings that lists the types of desktop sources to be captured, available types are screen and window.",
                 "required": true


### PR DESCRIPTION
In DesktopCapturer.getSource function, types should be Array<String> instead of String