### PR TITLE
electron.main.Session fix

### DIFF
--- a/src/electron/main/Session.hx
+++ b/src/electron/main/Session.hx
@@ -5,7 +5,9 @@ package electron.main;
 
 	See: <http://electron.atom.io/docs/api/session>
 **/
-@:require(js, electron) @:jsRequire("electron", "Session") extern class Session extends js.node.events.EventEmitter<electron.main.Session> {
+@:require(js, electron) 
+@:jsRequire("electron", "session") 
+extern class Session extends js.node.events.EventEmitter<electron.main.Session> {
 	/**
 		A Cookies object for this session.
 	**/
@@ -157,7 +159,9 @@ package electron.main;
 
 /**
 **/
-@:require(js, electron) @:enum abstract SessionEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+@:require(js, electron) 
+@:enum 
+abstract SessionEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
 	/**
 		Emitted when Electron is about to download item in webContents. Calling event.preventDefault() will cancel the download and item will not be available from next tick of the process.
 	**/

--- a/src/electron/main/Session.hx
+++ b/src/electron/main/Session.hx
@@ -155,6 +155,11 @@ extern class Session extends js.node.events.EventEmitter<electron.main.Session> 
 		Clears the session’s HTTP authentication cache.
 	**/
 	function clearAuthCache(options:Dynamic, ?callback:haxe.Constraints.Function):Void;
+
+	/**
+	    Returns a Session instance from [partition] String
+	**/
+	static function fromPartition(partition:String, ?options:{cache:Bool}):Session;
 }
 
 /**


### PR DESCRIPTION
Corrects invalid @:jsRequire path, and adds missing electron.session.fromPartition method