### PR TITLE
Add remote types

### DIFF
--- a/src/electron/remote/App.hx
+++ b/src/electron/remote/App.hx
@@ -1,0 +1,738 @@
+package electron.remote;
+/**
+	> Control your application's event lifecycle.
+	
+	Process: Main
+	
+	The following example shows how to quit the application when the last window is closed:
+	@see https://electronjs.org/docs/api/app
+**/
+@:jsRequire("electron", "remote.app") extern class App extends js.node.events.EventEmitter<electron.main.App> {
+	/**
+		A `Boolean` property that's `true` if Chrome's accessibility support is enabled, `false` otherwise. This property will be `true` if the use of assistive technologies, such as screen readers, has been detected. Setting this property to `true` manually enables Chrome's accessibility support, allowing developers to expose accessibility switch to users in application settings.
+		
+		See Chromium's accessibility docs for more details. Disabled by default.
+		
+		This API must be called after the `ready` event is emitted.
+		
+		**Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
+	**/
+	static var accessibilitySupportEnabled : Bool;
+	/**
+		A `Menu | null` property that returns `Menu` if one has been set and `null` otherwise. Users can pass a Menu to set this property.
+	**/
+	static var applicationMenu : haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		An `Integer` property that returns the badge count for current app. Setting the count to `0` will hide the badge.
+		
+		On macOS, setting this with any nonzero integer shows on the dock icon. On Linux, this property only works for Unity launcher.
+		
+		**Note:** Unity launcher requires the existence of a `.desktop` file to work, for more information please read Desktop Environment Integration.
+		
+		**Note:** On macOS, you need to ensure that your application has the permission to display notifications for this property to take effect.
+	**/
+	static var badgeCount : Int;
+	/**
+		A `CommandLine` object that allows you to read and manipulate the command line arguments that Chromium uses.
+	**/
+	static var commandLine : electron.main.CommandLine;
+	/**
+		A `Dock` `| undefined` object that allows you to perform actions on your app icon in the user's dock on macOS.
+	**/
+	static var dock : electron.main.Dock;
+	/**
+		A `Boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
+	**/
+	static var isPackaged : Bool;
+	/**
+		A `String` property that indicates the current application's name, which is the name in the application's `package.json` file.
+		
+		Usually the `name` field of `package.json` is a short lowercase name, according to the npm modules spec. You should usually also specify a `productName` field, which is your application's full capitalized name, and which will be preferred over `name` by Electron.
+	**/
+	static var name : String;
+	/**
+		A `String` which is the user agent string Electron will use as a global fallback.
+		
+		This is the user agent that will be used when no user agent is set at the `webContents` or `session` level.  It is useful for ensuring that your entire app has the same user agent.  Set to a custom value as early as possible in your app's initialization to ensure that your overridden value is used.
+	**/
+	static var userAgentFallback : String;
+	/**
+		A `Boolean` which when `true` disables the overrides that Electron has in place to ensure renderer processes are restarted on every navigation.  The current default value for this property is `true`.
+		
+		The intention is for these overrides to become disabled by default and then at some point in the future this property will be removed.  This property impacts which native modules you can use in the renderer process.  For more information on the direction Electron is going with renderer process restarts and usage of native modules in the renderer process please check out this Tracking Issue.
+	**/
+	static var allowRendererProcessReuse : Bool;
+	/**
+		A `Boolean` which when `true` indicates that the app is currently running under the Rosetta Translator Environment.
+		
+		You can use this property to prompt users to download the arm64 version of your application when they are running the x64 version under Rosetta incorrectly.
+	**/
+	static var runningUnderRosettaTranslation : Bool;
+	/**
+		Try to close all windows. The `before-quit` event will be emitted first. If all windows are successfully closed, the `will-quit` event will be emitted and by default the application will terminate.
+		
+		This method guarantees that all `beforeunload` and `unload` event handlers are correctly executed. It is possible that a window cancels the quitting by returning `false` in the `beforeunload` event handler.
+	**/
+	static function quit():Void;
+	/**
+		Exits immediately with `exitCode`. `exitCode` defaults to 0.
+		
+		All windows will be closed immediately without asking the user, and the `before-quit` and `will-quit` events will not be emitted.
+	**/
+	static function exit(?exitCode:Int):Void;
+	/**
+		Relaunches the app when current instance exits.
+		
+		By default, the new instance will use the same working directory and command line arguments with current instance. When `args` is specified, the `args` will be passed as command line arguments instead. When `execPath` is specified, the `execPath` will be executed for relaunch instead of current app.
+		
+		Note that this method does not quit the app when executed, you have to call `app.quit` or `app.exit` after calling `app.relaunch` to make the app restart.
+		
+		When `app.relaunch` is called for multiple times, multiple instances will be started after current instance exited.
+		
+		An example of restarting current instance immediately and adding a new command line argument to the new instance:
+	**/
+	static function relaunch(?options:{ @:optional
+	var args : Array<String>; @:optional
+	var execPath : String; }):Void;
+	/**
+		`true` if Electron has finished initializing, `false` otherwise. See also `app.whenReady()`.
+	**/
+	static function isReady():Bool;
+	/**
+		fulfilled when Electron is initialized. May be used as a convenient alternative to checking `app.isReady()` and subscribing to the `ready` event if the app is not ready yet.
+	**/
+	static function whenReady():js.lib.Promise<Any>;
+	/**
+		On Linux, focuses on the first visible window. On macOS, makes the application the active app. On Windows, focuses on the application's first window.
+		
+		You should seek to use the `steal` option as sparingly as possible.
+	**/
+	static function focus(?options:{ /**
+		Make the receiver the active app even if another app is currently active.
+	**/
+	var steal : Bool; }):Void;
+	/**
+		Hides all application windows without minimizing them.
+	**/
+	static function hide():Void;
+	/**
+		Shows application windows after they were hidden. Does not automatically focus them.
+	**/
+	static function show():Void;
+	/**
+		Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
+		
+		Calling `app.setAppLogsPath()` without a `path` parameter will result in this directory being set to `~/Library/Logs/YourAppName` on _macOS_, and inside the `userData` directory on _Linux_ and _Windows_.
+	**/
+	static function setAppLogsPath(?path:String):Void;
+	/**
+		The current application directory.
+	**/
+	static function getAppPath():String;
+	/**
+		A path to a special directory or file associated with `name`. On failure, an `Error` is thrown.
+		
+		If `app.getPath('logs')` is called without called `app.setAppLogsPath()` being called first, a default log directory will be created equivalent to calling `app.setAppLogsPath()` without a `path` parameter.
+	**/
+	static function getPath(name:String):String;
+	/**
+		fulfilled with the app's icon, which is a NativeImage.
+		
+		Fetches a path's associated icon.
+		
+		On _Windows_, there a 2 kinds of icons:
+		
+		* Icons associated with certain file extensions, like `.mp3`, `.png`, etc.
+		* Icons inside the file itself, like `.exe`, `.dll`, `.ico`.
+		
+		On _Linux_ and _macOS_, icons depend on the application associated with file mime type.
+	**/
+	static function getFileIcon(path:String, ?options:{ var size : String; }):js.lib.Promise<Any>;
+	/**
+		Overrides the `path` to a special directory or file associated with `name`. If the path specifies a directory that does not exist, an `Error` is thrown. In that case, the directory should be created with `fs.mkdirSync` or similar.
+		
+		You can only override paths of a `name` defined in `app.getPath`.
+		
+		By default, web pages' cookies and caches will be stored under the `userData` directory. If you want to change this location, you have to override the `userData` path before the `ready` event of the `app` module is emitted.
+	**/
+	static function setPath(name:String, path:String):Void;
+	/**
+		The version of the loaded application. If no version is found in the application's `package.json` file, the version of the current bundle or executable is returned.
+	**/
+	static function getVersion():String;
+	/**
+		The current application's name, which is the name in the application's `package.json` file.
+		
+		Usually the `name` field of `package.json` is a short lowercase name, according to the npm modules spec. You should usually also specify a `productName` field, which is your application's full capitalized name, and which will be preferred over `name` by Electron.
+	**/
+	static function getName():String;
+	/**
+		Overrides the current application's name.
+		
+		**Note:** This function overrides the name used internally by Electron; it does not affect the name that the OS uses.
+	**/
+	static function setName(name:String):Void;
+	/**
+		The current application locale. Possible return values are documented here.
+		
+		To set the locale, you'll want to use a command line switch at app startup, which may be found here.
+		
+		**Note:** When distributing your packaged app, you have to also ship the `locales` folder.
+		
+		**Note:** On Windows, you have to call it after the `ready` events gets emitted.
+	**/
+	static function getLocale():String;
+	/**
+		User operating system's locale two-letter ISO 3166 country code. The value is taken from native OS APIs.
+		
+		**Note:** When unable to detect locale country code, it returns empty string.
+	**/
+	static function getLocaleCountryCode():String;
+	/**
+		Adds `path` to the recent documents list.
+		
+		This list is managed by the OS. On Windows, you can visit the list from the task bar, and on macOS, you can visit it from dock menu.
+	**/
+	static function addRecentDocument(path:String):Void;
+	/**
+		Clears the recent documents list.
+	**/
+	static function clearRecentDocuments():Void;
+	/**
+		Whether the call succeeded.
+		
+		Sets the current executable as the default handler for a protocol (aka URI scheme). It allows you to integrate your app deeper into the operating system. Once registered, all links with `your-protocol://` will be opened with the current executable. The whole link, including protocol, will be passed to your application as a parameter.
+		
+		**Note:** On macOS, you can only register protocols that have been added to your app's `info.plist`, which cannot be modified at runtime. However, you can change the file during build time via Electron Forge, Electron Packager, or by editing `info.plist` with a text editor. Please refer to Apple's documentation for details.
+		
+		**Note:** In a Windows Store environment (when packaged as an `appx`) this API will return `true` for all calls but the registry key it sets won't be accessible by other applications.  In order to register your Windows Store application as a default protocol handler you must declare the protocol in your manifest.
+		
+		The API uses the Windows Registry and `LSSetDefaultHandlerForURLScheme` internally.
+	**/
+	static function setAsDefaultProtocolClient(protocol:String, ?path:String, ?args:Array<String>):Bool;
+	/**
+		Whether the call succeeded.
+		
+		This method checks if the current executable as the default handler for a protocol (aka URI scheme). If so, it will remove the app as the default handler.
+	**/
+	static function removeAsDefaultProtocolClient(protocol:String, ?path:String, ?args:Array<String>):Bool;
+	/**
+		Whether the current executable is the default handler for a protocol (aka URI scheme).
+		
+		**Note:** On macOS, you can use this method to check if the app has been registered as the default protocol handler for a protocol. You can also verify this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the macOS machine. Please refer to Apple's documentation for details.
+		
+		The API uses the Windows Registry and `LSCopyDefaultHandlerForURLScheme` internally.
+	**/
+	static function isDefaultProtocolClient(protocol:String, ?path:String, ?args:Array<String>):Bool;
+	/**
+		Name of the application handling the protocol, or an empty string if there is no handler. For instance, if Electron is the default handler of the URL, this could be `Electron` on Windows and Mac. However, don't rely on the precise format which is not guaranteed to remain unchanged. Expect a different format on Linux, possibly with a `.desktop` suffix.
+		
+		This method returns the application name of the default handler for the protocol (aka URI scheme) of a URL.
+	**/
+	static function getApplicationNameForProtocol(url:String):String;
+	/**
+		Resolve with an object containing the following:
+		
+		* `icon` NativeImage - the display icon of the app handling the protocol.
+		* `path` String  - installation path of the app handling the protocol.
+		* `name` String - display name of the app handling the protocol.
+		
+		This method returns a promise that contains the application name, icon and path of the default handler for the protocol (aka URI scheme) of a URL.
+	**/
+	static function getApplicationInfoForProtocol(url:String):js.lib.Promise<Any>;
+	/**
+		Adds `tasks` to the Tasks category of the Jump List on Windows.
+		
+		`tasks` is an array of `Task` objects.
+		
+		Whether the call succeeded.
+		
+		**Note:** If you'd like to customize the Jump List even more use `app.setJumpList(categories)` instead.
+	**/
+	static function setUserTasks(tasks:Array<electron.Task>):Bool;
+	/**
+		* `minItems` Integer - The minimum number of items that will be shown in the Jump List (for a more detailed description of this value see the MSDN docs).
+		* `removedItems` JumpListItem[] - Array of `JumpListItem` objects that correspond to items that the user has explicitly removed from custom categories in the Jump List. These items must not be re-added to the Jump List in the **next** call to `app.setJumpList()`, Windows will not display any custom category that contains any of the removed items.
+	**/
+	static function getJumpListSettings():Any;
+	/**
+		Sets or removes a custom Jump List for the application, and returns one of the following strings:
+		
+		* `ok` - Nothing went wrong.
+		* `error` - One or more errors occurred, enable runtime logging to figure out the likely cause.
+		* `invalidSeparatorError` - An attempt was made to add a separator to a custom category in the Jump List. Separators are only allowed in the standard `Tasks` category.
+		* `fileTypeRegistrationError` - An attempt was made to add a file link to the Jump List for a file type the app isn't registered to handle.
+		* `customCategoryAccessDeniedError` - Custom categories can't be added to the Jump List due to user privacy or group policy settings.
+		
+		If `categories` is `null` the previously set custom Jump List (if any) will be replaced by the standard Jump List for the app (managed by Windows).
+		
+		**Note:** If a `JumpListCategory` object has neither the `type` nor the `name` property set then its `type` is assumed to be `tasks`. If the `name` property is set but the `type` property is omitted then the `type` is assumed to be `custom`.
+		
+		**Note:** Users can remove items from custom categories, and Windows will not allow a removed item to be added back into a custom category until **after** the next successful call to `app.setJumpList(categories)`. Any attempt to re-add a removed item to a custom category earlier than that will result in the entire custom category being omitted from the Jump List. The list of removed items can be obtained using `app.getJumpListSettings()`.
+		
+		Here's a very simple example of creating a custom Jump List:
+	**/
+	static function setJumpList(categories:haxe.extern.EitherType<Array<Dynamic>, Dynamic>):Void;
+	/**
+		The return value of this method indicates whether or not this instance of your application successfully obtained the lock.  If it failed to obtain the lock, you can assume that another instance of your application is already running with the lock and exit immediately.
+		
+		I.e. This method returns `true` if your process is the primary instance of your application and your app should continue loading.  It returns `false` if your process should immediately quit as it has sent its parameters to another instance that has already acquired the lock.
+		
+		On macOS, the system enforces single instance automatically when users try to open a second instance of your app in Finder, and the `open-file` and `open-url` events will be emitted for that. However when users start your app in command line, the system's single instance mechanism will be bypassed, and you have to use this method to ensure single instance.
+		
+		An example of activating the window of primary instance when a second instance starts:
+	**/
+	static function requestSingleInstanceLock():Bool;
+	/**
+		This method returns whether or not this instance of your app is currently holding the single instance lock.  You can request the lock with `app.requestSingleInstanceLock()` and release with `app.releaseSingleInstanceLock()`
+	**/
+	static function hasSingleInstanceLock():Bool;
+	/**
+		Releases all locks that were created by `requestSingleInstanceLock`. This will allow multiple instances of the application to once again run side by side.
+	**/
+	static function releaseSingleInstanceLock():Void;
+	/**
+		Creates an `NSUserActivity` and sets it as the current activity. The activity is eligible for Handoff to another device afterward.
+	**/
+	static function setUserActivity(type:String, userInfo:Any, ?webpageURL:String):Void;
+	/**
+		The type of the currently running activity.
+	**/
+	static function getCurrentActivityType():String;
+	/**
+		Invalidates the current Handoff user activity.
+	**/
+	static function invalidateCurrentActivity():Void;
+	/**
+		Marks the current Handoff user activity as inactive without invalidating it.
+	**/
+	static function resignCurrentActivity():Void;
+	/**
+		Updates the current activity if its type matches `type`, merging the entries from `userInfo` into its current `userInfo` dictionary.
+	**/
+	static function updateCurrentActivity(type:String, userInfo:Any):Void;
+	/**
+		Changes the Application User Model ID to `id`.
+	**/
+	static function setAppUserModelId(id:String):Void;
+	/**
+		Sets the activation policy for a given app.
+		
+		Activation policy types:
+		
+		* 'regular' - The application is an ordinary app that appears in the Dock and may have a user interface.
+		* 'accessory' - The application doesn’t appear in the Dock and doesn’t have a menu bar, but it may be activated programmatically or by clicking on one of its windows.
+		* 'prohibited' - The application doesn’t appear in the Dock and may not create windows or be activated.
+	**/
+	static function setActivationPolicy(policy:String):Void;
+	/**
+		Imports the certificate in pkcs12 format into the platform certificate store. `callback` is called with the `result` of import operation, a value of `0` indicates success while any other value indicates failure according to Chromium net_error_list.
+	**/
+	static function importCertificate(options:{ /**
+		Path for the pkcs12 file.
+	**/
+	var certificate : String; /**
+		Passphrase for the certificate.
+	**/
+	var password : String; }, callback:haxe.Constraints.Function):Void;
+	/**
+		Disables hardware acceleration for current app.
+		
+		This method can only be called before app is ready.
+	**/
+	static function disableHardwareAcceleration():Void;
+	/**
+		By default, Chromium disables 3D APIs (e.g. WebGL) until restart on a per domain basis if the GPU processes crashes too frequently. This function disables that behavior.
+		
+		This method can only be called before app is ready.
+	**/
+	static function disableDomainBlockingFor3DAPIs():Void;
+	/**
+		Array of `ProcessMetric` objects that correspond to memory and CPU usage statistics of all the processes associated with the app.
+	**/
+	static function getAppMetrics():Array<electron.ProcessMetric>;
+	/**
+		The Graphics Feature Status from `chrome://gpu/`.
+		
+		**Note:** This information is only usable after the `gpu-info-update` event is emitted.
+	**/
+	static function getGPUFeatureStatus():electron.GPUFeatureStatus;
+	/**
+		For `infoType` equal to `complete`: Promise is fulfilled with `Object` containing all the GPU Information as in chromium's GPUInfo object. This includes the version and driver information that's shown on `chrome://gpu` page.
+		
+		For `infoType` equal to `basic`: Promise is fulfilled with `Object` containing fewer attributes than when requested with `complete`. Here's an example of basic response:
+		
+		Using `basic` should be preferred if only basic information like `vendorId` or `driverId` is needed.
+	**/
+	static function getGPUInfo(infoType:String):js.lib.Promise<Any>;
+	/**
+		Whether the call succeeded.
+		
+		Sets the counter badge for current app. Setting the count to `0` will hide the badge.
+		
+		On macOS, it shows on the dock icon. On Linux, it only works for Unity launcher.
+		
+		**Note:** Unity launcher requires the existence of a `.desktop` file to work, for more information please read Desktop Environment Integration.
+	**/
+	static function setBadgeCount(count:Int):Bool;
+	/**
+		The current value displayed in the counter badge.
+	**/
+	static function getBadgeCount():Int;
+	/**
+		Whether the current desktop environment is Unity launcher.
+	**/
+	static function isUnityRunning():Bool;
+	/**
+		If you provided `path` and `args` options to `app.setLoginItemSettings`, then you need to pass the same arguments here for `openAtLogin` to be set correctly.
+		
+		
+		* `openAtLogin` Boolean - `true` if the app is set to open at login.
+		* `openAsHidden` Boolean _macOS_ - `true` if the app is set to open as hidden at login. This setting is not available on MAS builds.
+		* `wasOpenedAtLogin` Boolean _macOS_ - `true` if the app was opened at login automatically. This setting is not available on MAS builds.
+		* `wasOpenedAsHidden` Boolean _macOS_ - `true` if the app was opened as a hidden login item. This indicates that the app should not open any windows at startup. This setting is not available on MAS builds.
+		* `restoreState` Boolean _macOS_ - `true` if the app was opened as a login item that should restore the state from the previous session. This indicates that the app should restore the windows that were open the last time the app was closed. This setting is not available on MAS builds.
+		* `executableWillLaunchAtLogin` Boolean _Windows_ - `true` if app is set to open at login and its run key is not deactivated. This differs from `openAtLogin` as it ignores the `args` option, this property will be true if the given executable would be launched at login with **any** arguments.
+		* `launchItems` Object[] _Windows_
+		  * `name` String _Windows_ - name value of a registry entry.
+		  * `path` String _Windows_ - The executable to an app that corresponds to a registry entry.
+		  * `args` String[] _Windows_ - the command-line arguments to pass to the executable.
+		  * `scope` String _Windows_ - one of `user` or `machine`. Indicates whether the registry entry is under `HKEY_CURRENT USER` or `HKEY_LOCAL_MACHINE`.
+		  * `enabled` Boolean _Windows_ - `true` if the app registry key is startup approved and therefore shows as `enabled` in Task Manager and Windows settings.
+	**/
+	static function getLoginItemSettings(?options:{ /**
+		The executable path to compare against. Defaults to `process.execPath`.
+	**/
+	@:optional
+	var path : String; /**
+		The command-line arguments to compare against. Defaults to an empty array.
+	**/
+	@:optional
+	var args : Array<String>; }):Any;
+	/**
+		To work with Electron's `autoUpdater` on Windows, which uses Squirrel, you'll want to set the launch path to Update.exe, and pass arguments that specify your application name. For example:
+	**/
+	static function setLoginItemSettings(settings:{ /**
+		`true` to open the app at login, `false` to remove the app as a login item. Defaults to `false`.
+	**/
+	@:optional
+	var openAtLogin : Bool; /**
+		`true` to open the app as hidden. Defaults to `false`. The user can edit this setting from the System Preferences so `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app is opened to know the current value. This setting is not available on MAS builds.
+	**/
+	@:optional
+	var openAsHidden : Bool; /**
+		The executable to launch at login. Defaults to `process.execPath`.
+	**/
+	@:optional
+	var path : String; /**
+		The command-line arguments to pass to the executable. Defaults to an empty array. Take care to wrap paths in quotes.
+	**/
+	@:optional
+	var args : Array<String>; /**
+		`true` will change the startup approved registry key and `enable / disable` the App in Task Manager and Windows Settings. Defaults to `true`.
+	**/
+	@:optional
+	var enabled : Bool; /**
+		value name to write into registry. Defaults to the app's AppUserModelId(). Set the app's login item settings.
+	**/
+	@:optional
+	var name : String; }):Void;
+	/**
+		`true` if Chrome's accessibility support is enabled, `false` otherwise. This API will return `true` if the use of assistive technologies, such as screen readers, has been detected. See https://www.chromium.org/developers/design-documents/accessibility for more details.
+	**/
+	static function isAccessibilitySupportEnabled():Bool;
+	/**
+		Manually enables Chrome's accessibility support, allowing to expose accessibility switch to users in application settings. See Chromium's accessibility docs for more details. Disabled by default.
+		
+		This API must be called after the `ready` event is emitted.
+		
+		**Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
+	**/
+	static function setAccessibilitySupportEnabled(enabled:Bool):Void;
+	/**
+		Show the app's about panel options. These options can be overridden with `app.setAboutPanelOptions(options)`.
+	**/
+	static function showAboutPanel():Void;
+	/**
+		Set the about panel options. This will override the values defined in the app's `.plist` file on macOS. See the Apple docs for more details. On Linux, values must be set in order to be shown; there are no defaults.
+		
+		If you do not set `credits` but still wish to surface them in your app, AppKit will look for a file named "Credits.html", "Credits.rtf", and "Credits.rtfd", in that order, in the bundle returned by the NSBundle class method main. The first file found is used, and if none is found, the info area is left blank. See Apple documentation for more information.
+	**/
+	static function setAboutPanelOptions(options:{ /**
+		The app's name.
+	**/
+	@:optional
+	var applicationName : String; /**
+		The app's version.
+	**/
+	@:optional
+	var applicationVersion : String; /**
+		Copyright information.
+	**/
+	@:optional
+	var copyright : String; /**
+		The app's build version number.
+	**/
+	@:optional
+	var version : String; /**
+		Credit information.
+	**/
+	@:optional
+	var credits : String; /**
+		List of app authors.
+	**/
+	@:optional
+	var authors : Array<String>; /**
+		The app's website.
+	**/
+	@:optional
+	var website : String; /**
+		Path to the app's icon in a JPEG or PNG file format. On Linux, will be shown as 64x64 pixels while retaining aspect ratio.
+	**/
+	@:optional
+	var iconPath : String; }):Void;
+	/**
+		whether or not the current OS version allows for native emoji pickers.
+	**/
+	static function isEmojiPanelSupported():Bool;
+	/**
+		Show the platform's native emoji picker.
+	**/
+	static function showEmojiPanel():Void;
+	/**
+		This function **must** be called once you have finished accessing the security scoped file. If you do not remember to stop accessing the bookmark, kernel resources will be leaked and your app will lose its ability to reach outside the sandbox completely, until your app is restarted.
+		
+		Start accessing a security scoped resource. With this method Electron applications that are packaged for the Mac App Store may reach outside their sandbox to access files chosen by the user. See Apple's documentation for a description of how this system works.
+	**/
+	static function startAccessingSecurityScopedResource(bookmarkData:String):haxe.Constraints.Function;
+	/**
+		Enables full sandbox mode on the app. This means that all renderers will be launched sandboxed, regardless of the value of the `sandbox` flag in WebPreferences.
+		
+		This method can only be called before app is ready.
+	**/
+	static function enableSandbox():Void;
+	/**
+		Whether the application is currently running from the systems Application folder. Use in combination with `app.moveToApplicationsFolder()`
+	**/
+	static function isInApplicationsFolder():Bool;
+	/**
+		Whether the move was successful. Please note that if the move is successful, your application will quit and relaunch.
+		
+		No confirmation dialog will be presented by default. If you wish to allow the user to confirm the operation, you may do so using the `dialog` API.
+		
+		**NOTE:** This method throws errors if anything other than the user causes the move to fail. For instance if the user cancels the authorization dialog, this method returns false. If we fail to perform the copy, then this method will throw an error. The message in the error should be informative and tell you exactly what went wrong.
+		
+		By default, if an app of the same name as the one being moved exists in the Applications directory and is _not_ running, the existing app will be trashed and the active app moved into its place. If it _is_ running, the pre-existing running app will assume focus and the previously active app will quit itself. This behavior can be changed by providing the optional conflict handler, where the boolean returned by the handler determines whether or not the move conflict is resolved with default behavior.  i.e. returning `false` will ensure no further action is taken, returning `true` will result in the default behavior and the method continuing.
+		
+		For example:
+		
+		Would mean that if an app already exists in the user directory, if the user chooses to 'Continue Move' then the function would continue with its default behavior and the existing app will be trashed and the active app moved into its place.
+	**/
+	static function moveToApplicationsFolder(?options:{ /**
+		A handler for potential conflict in move failure.
+	**/
+	@:optional
+	var conflictHandler : haxe.Constraints.Function; }):Bool;
+	/**
+		whether `Secure Keyboard Entry` is enabled.
+		
+		By default this API will return `false`.
+	**/
+	static function isSecureKeyboardEntryEnabled():Bool;
+	/**
+		Set the `Secure Keyboard Entry` is enabled in your application.
+		
+		By using this API, important information such as password and other sensitive information can be prevented from being intercepted by other processes.
+		
+		See Apple's documentation for more details.
+		
+		**Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
+	**/
+	static function setSecureKeyboardEntryEnabled(enabled:Bool):Void;
+	static function on<T:(haxe.Constraints.Function)>(eventType:Dynamic, callback:T):Void;
+}
+@:enum abstract AppEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the application has finished basic startup. On Windows and Linux, the `will-finish-launching` event is the same as the `ready` event; on macOS, this event represents the `applicationWillFinishLaunching` notification of `NSApplication`. You would usually set up listeners for the `open-file` and `open-url` events here, and start the crash reporter and auto updater.
+		
+		In most cases, you should do everything in the `ready` event handler.
+	**/
+	var will_finish_launching : electron.main.AppEvent<Void -> Void> = "will-finish-launching";
+	/**
+		Emitted once, when Electron has finished initializing. On macOS, `launchInfo` holds the `userInfo` of the `NSUserNotification` that was used to open the application, if it was launched from Notification Center. You can also call `app.isReady()` to check if this event has already fired and `app.whenReady()` to get a Promise that is fulfilled when Electron is initialized.
+	**/
+	var ready : electron.main.AppEvent<Void -> Void> = "ready";
+	/**
+		Emitted when all windows have been closed.
+		
+		If you do not subscribe to this event and all windows are closed, the default behavior is to quit the app; however, if you subscribe, you control whether the app quits or not. If the user pressed `Cmd + Q`, or the developer called `app.quit()`, Electron will first try to close all the windows and then emit the `will-quit` event, and in this case the `window-all-closed` event would not be emitted.
+	**/
+	var window_all_closed : electron.main.AppEvent<Void -> Void> = "window-all-closed";
+	/**
+		Emitted before the application starts closing its windows. Calling `event.preventDefault()` will prevent the default behavior, which is terminating the application.
+		
+		**Note:** If application quit was initiated by `autoUpdater.quitAndInstall()`, then `before-quit` is emitted *after* emitting `close` event on all windows and closing them.
+		
+		**Note:** On Windows, this event will not be emitted if the app is closed due to a shutdown/restart of the system or a user logout.
+	**/
+	var before_quit : electron.main.AppEvent<Void -> Void> = "before-quit";
+	/**
+		Emitted when all windows have been closed and the application will quit. Calling `event.preventDefault()` will prevent the default behavior, which is terminating the application.
+		
+		See the description of the `window-all-closed` event for the differences between the `will-quit` and `window-all-closed` events.
+		
+		**Note:** On Windows, this event will not be emitted if the app is closed due to a shutdown/restart of the system or a user logout.
+	**/
+	var will_quit : electron.main.AppEvent<Void -> Void> = "will-quit";
+	/**
+		Emitted when the application is quitting.
+		
+		**Note:** On Windows, this event will not be emitted if the app is closed due to a shutdown/restart of the system or a user logout.
+	**/
+	var quit : electron.main.AppEvent<Void -> Void> = "quit";
+	/**
+		Emitted when the user wants to open a file with the application. The `open-file` event is usually emitted when the application is already open and the OS wants to reuse the application to open the file. `open-file` is also emitted when a file is dropped onto the dock and the application is not yet running. Make sure to listen for the `open-file` event very early in your application startup to handle this case (even before the `ready` event is emitted).
+		
+		You should call `event.preventDefault()` if you want to handle this event.
+		
+		On Windows, you have to parse `process.argv` (in the main process) to get the filepath.
+	**/
+	var open_file : electron.main.AppEvent<Void -> Void> = "open-file";
+	/**
+		Emitted when the user wants to open a URL with the application. Your application's `Info.plist` file must define the URL scheme within the `CFBundleURLTypes` key, and set `NSPrincipalClass` to `AtomApplication`.
+		
+		You should call `event.preventDefault()` if you want to handle this event.
+	**/
+	var open_url : electron.main.AppEvent<Void -> Void> = "open-url";
+	/**
+		Emitted when the application is activated. Various actions can trigger this event, such as launching the application for the first time, attempting to re-launch the application when it's already running, or clicking on the application's dock or taskbar icon.
+	**/
+	var activate : electron.main.AppEvent<Void -> Void> = "activate";
+	/**
+		Emitted when mac application become active. Difference from `activate` event is that `did-become-active` is emitted every time the app becomes active, not only when Dock icon is clicked or application is re-launched.
+	**/
+	var did_become_active : electron.main.AppEvent<Void -> Void> = "did-become-active";
+	/**
+		Emitted during Handoff when an activity from a different device wants to be resumed. You should call `event.preventDefault()` if you want to handle this event.
+		
+		A user activity can be continued only in an app that has the same developer Team ID as the activity's source app and that supports the activity's type. Supported activity types are specified in the app's `Info.plist` under the `NSUserActivityTypes` key.
+	**/
+	var continue_activity : electron.main.AppEvent<Void -> Void> = "continue-activity";
+	/**
+		Emitted during Handoff before an activity from a different device wants to be resumed. You should call `event.preventDefault()` if you want to handle this event.
+	**/
+	var will_continue_activity : electron.main.AppEvent<Void -> Void> = "will-continue-activity";
+	/**
+		Emitted during Handoff when an activity from a different device fails to be resumed.
+	**/
+	var continue_activity_error : electron.main.AppEvent<Void -> Void> = "continue-activity-error";
+	/**
+		Emitted during Handoff after an activity from this device was successfully resumed on another one.
+	**/
+	var activity_was_continued : electron.main.AppEvent<Void -> Void> = "activity-was-continued";
+	/**
+		Emitted when Handoff is about to be resumed on another device. If you need to update the state to be transferred, you should call `event.preventDefault()` immediately, construct a new `userInfo` dictionary and call `app.updateCurrentActivity()` in a timely manner. Otherwise, the operation will fail and `continue-activity-error` will be called.
+	**/
+	var update_activity_state : electron.main.AppEvent<Void -> Void> = "update-activity-state";
+	/**
+		Emitted when the user clicks the native macOS new tab button. The new tab button is only visible if the current `BrowserWindow` has a `tabbingIdentifier`
+	**/
+	var new_window_for_tab : electron.main.AppEvent<Void -> Void> = "new-window-for-tab";
+	/**
+		Emitted when a browserWindow gets blurred.
+	**/
+	var browser_window_blur : electron.main.AppEvent<Void -> Void> = "browser-window-blur";
+	/**
+		Emitted when a browserWindow gets focused.
+	**/
+	var browser_window_focus : electron.main.AppEvent<Void -> Void> = "browser-window-focus";
+	/**
+		Emitted when a new browserWindow is created.
+	**/
+	var browser_window_created : electron.main.AppEvent<Void -> Void> = "browser-window-created";
+	/**
+		Emitted when a new webContents is created.
+	**/
+	var web_contents_created : electron.main.AppEvent<Void -> Void> = "web-contents-created";
+	/**
+		Emitted when failed to verify the `certificate` for `url`, to trust the certificate you should prevent the default behavior with `event.preventDefault()` and call `callback(true)`.
+	**/
+	var certificate_error : electron.main.AppEvent<Void -> Void> = "certificate-error";
+	/**
+		Emitted when a client certificate is requested.
+		
+		The `url` corresponds to the navigation entry requesting the client certificate and `callback` can be called with an entry filtered from the list. Using `event.preventDefault()` prevents the application from using the first certificate from the store.
+	**/
+	var select_client_certificate : electron.main.AppEvent<Void -> Void> = "select-client-certificate";
+	/**
+		Emitted when `webContents` wants to do basic auth.
+		
+		The default behavior is to cancel all authentications. To override this you should prevent the default behavior with `event.preventDefault()` and call `callback(username, password)` with the credentials.
+		
+		If `callback` is called without a username or password, the authentication request will be cancelled and the authentication error will be returned to the page.
+	**/
+	var login : electron.main.AppEvent<Void -> Void> = "login";
+	/**
+		Emitted whenever there is a GPU info update.
+	**/
+	var gpu_info_update : electron.main.AppEvent<Void -> Void> = "gpu-info-update";
+	/**
+		Emitted when the GPU process crashes or is killed.
+		
+		**Deprecated:** This event is superceded by the `child-process-gone` event which contains more information about why the child process disappeared. It isn't always because it crashed. The `killed` boolean can be replaced by checking `reason === 'killed'` when you switch to that event.
+	**/
+	var gpu_process_crashed : electron.main.AppEvent<Void -> Void> = "gpu-process-crashed";
+	var renderer_process_crashed : electron.main.AppEvent<Void -> Void> = "renderer-process-crashed";
+	/**
+		Emitted when the renderer process unexpectedly disappears.  This is normally because it was crashed or killed.
+	**/
+	var render_process_gone : electron.main.AppEvent<Void -> Void> = "render-process-gone";
+	/**
+		Emitted when the child process unexpectedly disappears. This is normally because it was crashed or killed. It does not include renderer processes.
+	**/
+	var child_process_gone : electron.main.AppEvent<Void -> Void> = "child-process-gone";
+	/**
+		Emitted when Chrome's accessibility support changes. This event fires when assistive technologies, such as screen readers, are enabled or disabled. See https://www.chromium.org/developers/design-documents/accessibility for more details.
+	**/
+	var accessibility_support_changed : electron.main.AppEvent<Void -> Void> = "accessibility-support-changed";
+	/**
+		Emitted when Electron has created a new `session`.
+	**/
+	var session_created : electron.main.AppEvent<Void -> Void> = "session-created";
+	/**
+		This event will be emitted inside the primary instance of your application when a second instance has been executed and calls `app.requestSingleInstanceLock()`.
+		
+		`argv` is an Array of the second instance's command line arguments, and `workingDirectory` is its current working directory. Usually applications respond to this by making their primary window focused and non-minimized.
+		
+		**Note:** If the second instance is started by a different user than the first, the `argv` array will not include the arguments.
+		
+		This event is guaranteed to be emitted after the `ready` event of `app` gets emitted.
+		
+		**Note:** Extra command line arguments might be added by Chromium, such as `--original-process-start-time`.
+	**/
+	var second_instance : electron.main.AppEvent<Void -> Void> = "second-instance";
+	/**
+		Emitted when `desktopCapturer.getSources()` is called in the renderer process of `webContents`. Calling `event.preventDefault()` will make it return empty sources.
+	**/
+	var desktop_capturer_get_sources : electron.main.AppEvent<Void -> Void> = "desktop-capturer-get-sources";
+	/**
+		Emitted when `remote.require()` is called in the renderer process of `webContents`. Calling `event.preventDefault()` will prevent the module from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_require : electron.main.AppEvent<Void -> Void> = "remote-require";
+	/**
+		Emitted when `remote.getGlobal()` is called in the renderer process of `webContents`. Calling `event.preventDefault()` will prevent the global from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_global : electron.main.AppEvent<Void -> Void> = "remote-get-global";
+	/**
+		Emitted when `remote.getBuiltin()` is called in the renderer process of `webContents`. Calling `event.preventDefault()` will prevent the module from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_builtin : electron.main.AppEvent<Void -> Void> = "remote-get-builtin";
+	/**
+		Emitted when `remote.getCurrentWindow()` is called in the renderer process of `webContents`. Calling `event.preventDefault()` will prevent the object from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_current_window : electron.main.AppEvent<Void -> Void> = "remote-get-current-window";
+	/**
+		Emitted when `remote.getCurrentWebContents()` is called in the renderer process of `webContents`. Calling `event.preventDefault()` will prevent the object from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_current_web_contents : electron.main.AppEvent<Void -> Void> = "remote-get-current-web-contents";
+}

--- a/src/electron/remote/AutoUpdater.hx
+++ b/src/electron/remote/AutoUpdater.hx
@@ -1,0 +1,95 @@
+package electron.remote;
+/**
+	> Enable apps to automatically update themselves.
+	
+	Process: Main
+	
+	**See also: A detailed guide about how to implement updates in your application.**
+	
+	`autoUpdater` is an EventEmitter.
+	
+	### Platform Notices
+	
+	Currently, only macOS and Windows are supported. There is no built-in support for auto-updater on Linux, so it is recommended to use the distribution's package manager to update your app.
+	
+	In addition, there are some subtle differences on each platform:
+	
+	### macOS
+	
+	On macOS, the `autoUpdater` module is built upon Squirrel.Mac, meaning you don't need any special setup to make it work. For server-side requirements, you can read Server Support. Note that App Transport Security (ATS) applies to all requests made as part of the update process. Apps that need to disable ATS can add the `NSAllowsArbitraryLoads` key to their app's plist.
+	
+	**Note:** Your application must be signed for automatic updates on macOS. This is a requirement of `Squirrel.Mac`.
+	
+	### Windows
+	
+	On Windows, you have to install your app into a user's machine before you can use the `autoUpdater`, so it is recommended that you use the electron-winstaller, electron-forge or the grunt-electron-installer package to generate a Windows installer.
+	
+	When using electron-winstaller or electron-forge make sure you do not try to update your app the first time it runs (Also see this issue for more info). It's also recommended to use electron-squirrel-startup to get desktop shortcuts for your app.
+	
+	The installer generated with Squirrel will create a shortcut icon with an Application User Model ID in the format of `com.squirrel.PACKAGE_ID.YOUR_EXE_WITHOUT_DOT_EXE`, examples are `com.squirrel.slack.Slack` and `com.squirrel.code.Code`. You have to use the same ID for your app with `app.setAppUserModelId` API, otherwise Windows will not be able to pin your app properly in task bar.
+	
+	Unlike Squirrel.Mac, Windows can host updates on S3 or any other static file host. You can read the documents of Squirrel.Windows to get more details about how Squirrel.Windows works.
+	@see https://electronjs.org/docs/api/auto-updater
+**/
+@:jsRequire("electron", "remote.autoUpdater") extern class AutoUpdater extends js.node.events.EventEmitter<electron.main.AutoUpdater> {
+	/**
+		Sets the `url` and initialize the auto updater.
+	**/
+	static function setFeedURL(options:{ var url : String; /**
+		HTTP request headers.
+	**/
+	@:optional
+	var headers : Record; /**
+		Can be `json` or `default`, see the Squirrel.Mac README for more information.
+	**/
+	@:optional
+	var serverType : String; }):Void;
+	/**
+		The current update feed URL.
+	**/
+	static function getFeedURL():String;
+	/**
+		Asks the server whether there is an update. You must call `setFeedURL` before using this API.
+	**/
+	static function checkForUpdates():Void;
+	/**
+		Restarts the app and installs the update after it has been downloaded. It should only be called after `update-downloaded` has been emitted.
+		
+		Under the hood calling `autoUpdater.quitAndInstall()` will close all application windows first, and automatically call `app.quit()` after all windows have been closed.
+		
+		**Note:** It is not strictly necessary to call this function to apply an update, as a successfully downloaded update will always be applied the next time the application starts.
+	**/
+	static function quitAndInstall():Void;
+}
+@:enum abstract AutoUpdaterEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when there is an error while updating.
+	**/
+	var error : electron.main.AutoUpdaterEvent<Void -> Void> = "error";
+	/**
+		Emitted when checking if an update has started.
+	**/
+	var checking_for_update : electron.main.AutoUpdaterEvent<Void -> Void> = "checking-for-update";
+	/**
+		Emitted when there is an available update. The update is downloaded automatically.
+	**/
+	var update_available : electron.main.AutoUpdaterEvent<Void -> Void> = "update-available";
+	/**
+		Emitted when there is no available update.
+	**/
+	var update_not_available : electron.main.AutoUpdaterEvent<Void -> Void> = "update-not-available";
+	/**
+		Emitted when an update has been downloaded.
+		
+		On Windows only `releaseName` is available.
+		
+		**Note:** It is not strictly necessary to handle this event. A successfully downloaded update will still be applied the next time the application starts.
+	**/
+	var update_downloaded : electron.main.AutoUpdaterEvent<Void -> Void> = "update-downloaded";
+	/**
+		This event is emitted after a user calls `quitAndInstall()`.
+		
+		When this API is called, the `before-quit` event is not emitted before all windows are closed. As a result you should listen to this event if you wish to perform actions before the windows are closed while a process is quitting, as well as listening to `before-quit`.
+	**/
+	var before_quit_for_update : electron.main.AutoUpdaterEvent<Void -> Void> = "before-quit-for-update";
+}

--- a/src/electron/remote/BrowserView.hx
+++ b/src/electron/remote/BrowserView.hx
@@ -1,0 +1,63 @@
+package electron.remote;
+/**
+	> Create and control views.
+	
+	Process: Main
+	
+	A `BrowserView` can be used to embed additional web content into a `BrowserWindow`. It is like a child window, except that it is positioned relative to its owning window. It is meant to be an alternative to the `webview` tag.
+	
+	### Example
+	
+	```
+	// In the main process.
+	const { BrowserView, BrowserWindow } = require('electron')
+	
+	const win = new BrowserWindow({ width: 800, height: 600 })
+	
+	const view = new BrowserView()
+	win.setBrowserView(view)
+	view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+	view.webContents.loadURL('https://electronjs.org')
+	```
+	@see https://electronjs.org/docs/api/browser-view
+**/
+@:jsRequire("electron", "remote.BrowserView") extern class BrowserView extends js.node.events.EventEmitter<electron.main.BrowserView> {
+	/**
+		A `WebContents` object owned by this view.
+	**/
+	var webContents : electron.main.WebContents;
+	function new(?options:{ /**
+		See BrowserWindow.
+	**/
+	@:optional
+	var webPreferences : Any; }):Void;
+	function setAutoResize(options:{ /**
+		If `true`, the view's width will grow and shrink together with the window. `false` by default.
+	**/
+	@:optional
+	var width : Bool; /**
+		If `true`, the view's height will grow and shrink together with the window. `false` by default.
+	**/
+	@:optional
+	var height : Bool; /**
+		If `true`, the view's x position and width will grow and shrink proportionally with the window. `false` by default.
+	**/
+	@:optional
+	var horizontal : Bool; /**
+		If `true`, the view's y position and height will grow and shrink proportionally with the window. `false` by default.
+	**/
+	@:optional
+	var vertical : Bool; }):Void;
+	/**
+		Resizes and moves the view to the supplied bounds relative to the window.
+	**/
+	function setBounds(bounds:electron.Rectangle):Void;
+	/**
+		The `bounds` of this BrowserView instance as `Object`.
+	**/
+	function getBounds():electron.Rectangle;
+	function setBackgroundColor(color:String):Void;
+}
+@:enum abstract BrowserViewEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/BrowserWindow.hx
+++ b/src/electron/remote/BrowserWindow.hx
@@ -1,0 +1,1486 @@
+package electron.remote;
+/**
+	> Create and control browser windows.
+	
+	Process: Main
+	
+	### Frameless window
+	
+	To create a window without chrome, or a transparent window in arbitrary shape, you can use the Frameless Window API.
+	
+	### Showing window gracefully
+	
+	When loading a page in the window directly, users may see the page load incrementally, which is not a good experience for a native app. To make the window display without visual flash, there are two solutions for different situations.
+	
+	### Using `ready-to-show` event
+	
+	While loading the page, the `ready-to-show` event will be emitted when the renderer process has rendered the page for the first time if the window has not been shown yet. Showing the window after this event will have no visual flash:
+	
+	```
+	const { BrowserWindow } = require('electron')
+	const win = new BrowserWindow({ show: false })
+	win.once('ready-to-show', () => {
+	  win.show()
+	})
+	```
+	
+	This event is usually emitted after the `did-finish-load` event, but for pages with many remote resources, it may be emitted before the `did-finish-load` event.
+	
+	Please note that using this event implies that the renderer will be considered "visible" and paint even though `show` is false.  This event will never fire if you use `paintWhenInitiallyHidden: false`
+	
+	### Setting `backgroundColor`
+	
+	For a complex app, the `ready-to-show` event could be emitted too late, making the app feel slow. In this case, it is recommended to show the window immediately, and use a `backgroundColor` close to your app's background:
+	
+	```
+	const { BrowserWindow } = require('electron')
+	
+	const win = new BrowserWindow({ backgroundColor: '#2e2c29' })
+	win.loadURL('https://github.com')
+	```
+	
+	Note that even for apps that use `ready-to-show` event, it is still recommended to set `backgroundColor` to make app feel more native.
+	
+	### Parent and child windows
+	
+	By using `parent` option, you can create child windows:
+	
+	```
+	const { BrowserWindow } = require('electron')
+	
+	const top = new BrowserWindow()
+	const child = new BrowserWindow({ parent: top })
+	child.show()
+	top.show()
+	```
+	
+	The `child` window will always show on top of the `top` window.
+	
+	### Modal windows
+	
+	A modal window is a child window that disables parent window, to create a modal window, you have to set both `parent` and `modal` options:
+	
+	```
+	const { BrowserWindow } = require('electron')
+	
+	const child = new BrowserWindow({ parent: top, modal: true, show: false })
+	child.loadURL('https://github.com')
+	child.once('ready-to-show', () => {
+	  child.show()
+	})
+	```
+	
+	### Page visibility
+	
+	The Page Visibility API works as follows:
+	
+	* On all platforms, the visibility state tracks whether the window is hidden/minimized or not.
+	* Additionally, on macOS, the visibility state also tracks the window occlusion state. If the window is occluded (i.e. fully covered) by another window, the visibility state will be `hidden`. On other platforms, the visibility state will be `hidden` only when the window is minimized or explicitly hidden with `win.hide()`.
+	* If a `BrowserWindow` is created with `show: false`, the initial visibility state will be `visible` despite the window actually being hidden.
+	* If `backgroundThrottling` is disabled, the visibility state will remain `visible` even if the window is minimized, occluded, or hidden.
+	
+	It is recommended that you pause expensive operations when the visibility state is `hidden` in order to minimize power consumption.
+	
+	### Platform notices
+	
+	* On macOS modal windows will be displayed as sheets attached to the parent window.
+	* On macOS the child windows will keep the relative position to parent window when parent window moves, while on Windows and Linux child windows will not move.
+	* On Linux the type of modal windows will be changed to `dialog`.
+	* On Linux many desktop environments do not support hiding a modal window.
+	
+	### Class: BrowserWindow
+	
+	> Create and control browser windows.
+	
+	Process: Main
+	
+	`BrowserWindow` is an EventEmitter.
+	
+	It creates a new `BrowserWindow` with native properties as set by the `options`.
+	@see https://electronjs.org/docs/api/browser-window
+**/
+@:jsRequire("electron", "remote.BrowserWindow") extern class BrowserWindow extends js.node.events.EventEmitter<electron.main.BrowserWindow> {
+	/**
+		An array of all opened browser windows.
+	**/
+	static function getAllWindows():Array<electron.main.BrowserWindow>;
+	/**
+		The window that is focused in this application, otherwise returns `null`.
+	**/
+	static function getFocusedWindow():haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		The window that owns the given `webContents` or `null` if the contents are not owned by a window.
+	**/
+	static function fromWebContents(webContents:electron.main.WebContents):haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		The window that owns the given `browserView`. If the given view is not attached to any window, returns `null`.
+	**/
+	static function fromBrowserView(browserView:electron.main.BrowserView):haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		The window with the given `id`.
+	**/
+	static function fromId(id:Int):haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		Adds Chrome extension located at `path`, and returns extension's name.
+		
+		The method will also not return if the extension's manifest is missing or incomplete.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** This method is deprecated. Instead, use `ses.loadExtension(path)`.
+	**/
+	static function addExtension(path:String):Void;
+	/**
+		Remove a Chrome extension by name.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** This method is deprecated. Instead, use `ses.removeExtension(extension_id)`.
+	**/
+	static function removeExtension(name:String):Void;
+	/**
+		The keys are the extension names and each value is an Object containing `name` and `version` properties.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** This method is deprecated. Instead, use `ses.getAllExtensions()`.
+	**/
+	static function getExtensions():Record;
+	/**
+		Adds DevTools extension located at `path`, and returns extension's name.
+		
+		The extension will be remembered so you only need to call this API once, this API is not for programming use. If you try to add an extension that has already been loaded, this method will not return and instead log a warning to the console.
+		
+		The method will also not return if the extension's manifest is missing or incomplete.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** This method is deprecated. Instead, use `ses.loadExtension(path)`.
+	**/
+	static function addDevToolsExtension(path:String):Void;
+	/**
+		Remove a DevTools extension by name.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** This method is deprecated. Instead, use `ses.removeExtension(extension_id)`.
+	**/
+	static function removeDevToolsExtension(name:String):Void;
+	/**
+		The keys are the extension names and each value is an Object containing `name` and `version` properties.
+		
+		To check if a DevTools extension is installed you can run the following:
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** This method is deprecated. Instead, use `ses.getAllExtensions()`.
+	**/
+	static function getDevToolsExtensions():Record;
+	/**
+		A `WebContents` object this window owns. All web page related events and operations will be done via it.
+		
+		See the `webContents` documentation for its methods and events.
+	**/
+	var webContents : electron.main.WebContents;
+	/**
+		A `Integer` property representing the unique ID of the window. Each ID is unique among all `BrowserWindow` instances of the entire Electron application.
+	**/
+	var id : Int;
+	/**
+		A `Boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
+		
+		If the menu bar is already visible, setting this property to `true` won't hide it immediately.
+	**/
+	var autoHideMenuBar : Bool;
+	/**
+		A `Boolean` property that determines whether the window is in simple (pre-Lion) fullscreen mode.
+	**/
+	var simpleFullScreen : Bool;
+	/**
+		A `Boolean` property that determines whether the window is in fullscreen mode.
+	**/
+	var fullScreen : Bool;
+	/**
+		A `Boolean` property that determines whether the window is visible on all workspaces.
+		
+		**Note:** Always returns false on Windows.
+	**/
+	var visibleOnAllWorkspaces : Bool;
+	/**
+		A `Boolean` property that determines whether the window has a shadow.
+	**/
+	var shadow : Bool;
+	/**
+		A `Boolean` property that determines whether the menu bar should be visible.
+		
+		**Note:** If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
+	**/
+	var menuBarVisible : Bool;
+	/**
+		A `Boolean` property that determines whether the window is in kiosk mode.
+	**/
+	var kiosk : Bool;
+	/**
+		A `Boolean` property that specifies whether the window’s document has been edited.
+		
+		The icon in title bar will become gray when set to `true`.
+	**/
+	var documentEdited : Bool;
+	/**
+		A `String` property that determines the pathname of the file the window represents, and the icon of the file will show in window's title bar.
+	**/
+	var representedFilename : String;
+	/**
+		A `String` property that determines the title of the native window.
+		
+		**Note:** The title of the web page can be different from the title of the native window.
+	**/
+	var title : String;
+	/**
+		A `Boolean` property that determines whether the window can be manually minimized by user.
+		
+		On Linux the setter is a no-op, although the getter returns `true`.
+	**/
+	var minimizable : Bool;
+	/**
+		A `Boolean` property that determines whether the window can be manually maximized by user.
+		
+		On Linux the setter is a no-op, although the getter returns `true`.
+	**/
+	var maximizable : Bool;
+	/**
+		A `Boolean` property that determines whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
+	**/
+	var fullScreenable : Bool;
+	/**
+		A `Boolean` property that determines whether the window can be manually resized by user.
+	**/
+	var resizable : Bool;
+	/**
+		A `Boolean` property that determines whether the window can be manually closed by user.
+		
+		On Linux the setter is a no-op, although the getter returns `true`.
+	**/
+	var closable : Bool;
+	/**
+		A `Boolean` property that determines Whether the window can be moved by user.
+		
+		On Linux the setter is a no-op, although the getter returns `true`.
+	**/
+	var movable : Bool;
+	/**
+		A `Boolean` property that determines whether the window is excluded from the application’s Windows menu. `false` by default.
+	**/
+	var excludedFromShownWindowsMenu : Bool;
+	/**
+		A `String` property that defines an alternative title provided only to accessibility tools such as screen readers. This string is not directly visible to users.
+	**/
+	var accessibleTitle : String;
+	function new(?options:{ /**
+		Window's width in pixels. Default is `800`.
+	**/
+	@:optional
+	var width : Int; /**
+		Window's height in pixels. Default is `600`.
+	**/
+	@:optional
+	var height : Int; /**
+		(**required** if y is used) Window's left offset from screen. Default is to center the window.
+	**/
+	@:optional
+	var x : Int; /**
+		(**required** if x is used) Window's top offset from screen. Default is to center the window.
+	**/
+	@:optional
+	var y : Int; /**
+		The `width` and `height` would be used as web page's size, which means the actual window's size will include window frame's size and be slightly larger. Default is `false`.
+	**/
+	@:optional
+	var useContentSize : Bool; /**
+		Show window in the center of the screen.
+	**/
+	@:optional
+	var center : Bool; /**
+		Window's minimum width. Default is `0`.
+	**/
+	@:optional
+	var minWidth : Int; /**
+		Window's minimum height. Default is `0`.
+	**/
+	@:optional
+	var minHeight : Int; /**
+		Window's maximum width. Default is no limit.
+	**/
+	@:optional
+	var maxWidth : Int; /**
+		Window's maximum height. Default is no limit.
+	**/
+	@:optional
+	var maxHeight : Int; /**
+		Whether window is resizable. Default is `true`.
+	**/
+	@:optional
+	var resizable : Bool; /**
+		Whether window is movable. This is not implemented on Linux. Default is `true`.
+	**/
+	@:optional
+	var movable : Bool; /**
+		Whether window is minimizable. This is not implemented on Linux. Default is `true`.
+	**/
+	@:optional
+	var minimizable : Bool; /**
+		Whether window is maximizable. This is not implemented on Linux. Default is `true`.
+	**/
+	@:optional
+	var maximizable : Bool; /**
+		Whether window is closable. This is not implemented on Linux. Default is `true`.
+	**/
+	@:optional
+	var closable : Bool; /**
+		Whether the window can be focused. Default is `true`. On Windows setting `focusable: false` also implies setting `skipTaskbar: true`. On Linux setting `focusable: false` makes the window stop interacting with wm, so the window will always stay on top in all workspaces.
+	**/
+	@:optional
+	var focusable : Bool; /**
+		Whether the window should always stay on top of other windows. Default is `false`.
+	**/
+	@:optional
+	var alwaysOnTop : Bool; /**
+		Whether the window should show in fullscreen. When explicitly set to `false` the fullscreen button will be hidden or disabled on macOS. Default is `false`.
+	**/
+	@:optional
+	var fullscreen : Bool; /**
+		Whether the window can be put into fullscreen mode. On macOS, also whether the maximize/zoom button should toggle full screen mode or maximize window. Default is `true`.
+	**/
+	@:optional
+	var fullscreenable : Bool; /**
+		Use pre-Lion fullscreen on macOS. Default is `false`.
+	**/
+	@:optional
+	var simpleFullscreen : Bool; /**
+		Whether to show the window in taskbar. Default is `false`.
+	**/
+	@:optional
+	var skipTaskbar : Bool; /**
+		Whether the window is in kiosk mode. Default is `false`.
+	**/
+	@:optional
+	var kiosk : Bool; /**
+		Default window title. Default is `"Electron"`. If the HTML tag `<title>` is defined in the HTML file loaded by `loadURL()`, this property will be ignored.
+	**/
+	@:optional
+	var title : String; /**
+		The window icon. On Windows it is recommended to use `ICO` icons to get best visual effects, you can also leave it undefined so the executable's icon will be used.
+	**/
+	@:optional
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		Whether window should be shown when created. Default is `true`.
+	**/
+	@:optional
+	var show : Bool; /**
+		Whether the renderer should be active when `show` is `false` and it has just been created.  In order for `document.visibilityState` to work correctly on first load with `show: false` you should set this to `false`.  Setting this to `false` will cause the `ready-to-show` event to not fire.  Default is `true`.
+	**/
+	@:optional
+	var paintWhenInitiallyHidden : Bool; /**
+		Specify `false` to create a Frameless Window. Default is `true`.
+	**/
+	@:optional
+	var frame : Bool; /**
+		Specify parent window. Default is `null`.
+	**/
+	@:optional
+	var parent : electron.main.BrowserWindow; /**
+		Whether this is a modal window. This only works when the window is a child window. Default is `false`.
+	**/
+	@:optional
+	var modal : Bool; /**
+		Whether the web view accepts a single mouse-down event that simultaneously activates the window. Default is `false`.
+	**/
+	@:optional
+	var acceptFirstMouse : Bool; /**
+		Whether to hide cursor when typing. Default is `false`.
+	**/
+	@:optional
+	var disableAutoHideCursor : Bool; /**
+		Auto hide the menu bar unless the `Alt` key is pressed. Default is `false`.
+	**/
+	@:optional
+	var autoHideMenuBar : Bool; /**
+		Enable the window to be resized larger than screen. Only relevant for macOS, as other OSes allow larger-than-screen windows by default. Default is `false`.
+	**/
+	@:optional
+	var enableLargerThanScreen : Bool; /**
+		Window's background color as a hexadecimal value, like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha in #AARRGGBB format is supported if `transparent` is set to `true`). Default is `#FFF` (white).
+	**/
+	@:optional
+	var backgroundColor : String; /**
+		Whether window should have a shadow. Default is `true`.
+	**/
+	@:optional
+	var hasShadow : Bool; /**
+		Set the initial opacity of the window, between 0.0 (fully transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
+	**/
+	@:optional
+	var opacity : Float; /**
+		Forces using dark theme for the window, only works on some GTK+3 desktop environments. Default is `false`.
+	**/
+	@:optional
+	var darkTheme : Bool; /**
+		Makes the window transparent. Default is `false`. On Windows, does not work unless the window is frameless.
+	**/
+	@:optional
+	var transparent : Bool; /**
+		The type of window, default is normal window. See more about this below.
+	**/
+	@:optional
+	var type : String; /**
+		Specify how the material appearance should reflect window activity state on macOS. Must be used with the `vibrancy` property. Possible values are:
+	**/
+	@:optional
+	var visualEffectState : String; /**
+		The style of window title bar. Default is `default`. Possible values are:
+	**/
+	@:optional
+	var titleBarStyle : String; /**
+		Set a custom position for the traffic light buttons. Can only be used with `titleBarStyle` set to `hidden`
+	**/
+	@:optional
+	var trafficLightPosition : electron.Point; /**
+		Shows the title in the title bar in full screen mode on macOS for all `titleBarStyle` options. Default is `false`.
+	**/
+	@:optional
+	var fullscreenWindowTitle : Bool; /**
+		Use `WS_THICKFRAME` style for frameless windows on Windows, which adds standard window frame. Setting it to `false` will remove window shadow and window animations. Default is `true`.
+	**/
+	@:optional
+	var thickFrame : Bool; /**
+		Add a type of vibrancy effect to the window, only on macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`.  Please note that using `frame: false` in combination with a vibrancy value requires that you use a non-default `titleBarStyle` as well. Also note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been deprecated and will be removed in an upcoming version of macOS.
+	**/
+	@:optional
+	var vibrancy : String; /**
+		Controls the behavior on macOS when option-clicking the green stoplight button on the toolbar or by clicking the Window > Zoom menu item. If `true`, the window will grow to the preferred width of the web page when zoomed, `false` will cause it to zoom to the width of the screen. This will also affect the behavior when calling `maximize()` directly. Default is `false`.
+	**/
+	@:optional
+	var zoomToPageWidth : Bool; /**
+		Tab group name, allows opening the window as a native tab on macOS 10.12+. Windows with the same tabbing identifier will be grouped together. This also adds a native new tab button to your window's tab bar and allows your `app` and window to receive the `new-window-for-tab` event.
+	**/
+	@:optional
+	var tabbingIdentifier : String; /**
+		Settings of web page's features.
+	**/
+	@:optional
+	var webPreferences : { /**
+		Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
+	**/
+	@:optional
+	var devTools : Bool; /**
+		Whether node integration is enabled. Default is `false`.
+	**/
+	@:optional
+	var nodeIntegration : Bool; /**
+		Whether node integration is enabled in web workers. Default is `false`. More about this can be found in Multithreading.
+	**/
+	@:optional
+	var nodeIntegrationInWorker : Bool; /**
+		Experimental option for enabling Node.js support in sub-frames such as iframes and child windows. All your preloads will load for every iframe, you can use `process.isMainFrame` to determine if you are in the main frame or not.
+	**/
+	@:optional
+	var nodeIntegrationInSubFrames : Bool; /**
+		Specifies a script that will be loaded before other scripts run in the page. This script will always have access to node APIs no matter whether node integration is turned on or off. The value should be the absolute file path to the script. When node integration is turned off, the preload script can reintroduce Node global symbols back to the global scope. See example here.
+	**/
+	@:optional
+	var preload : String; /**
+		If set, this will sandbox the renderer associated with the window, making it compatible with the Chromium OS-level sandbox and disabling the Node.js engine. This is not the same as the `nodeIntegration` option and the APIs available to the preload script are more limited. Read more about the option here.
+	**/
+	@:optional
+	var sandbox : Bool; /**
+		Whether to enable the `remote` module. Default is `false`.
+	**/
+	@:optional
+	var enableRemoteModule : Bool; /**
+		Sets the session used by the page. Instead of passing the Session object directly, you can also choose to use the `partition` option instead, which accepts a partition string. When both `session` and `partition` are provided, `session` will be preferred. Default is the default session.
+	**/
+	@:optional
+	var session : electron.main.Session; /**
+		Sets the session used by the page according to the session's partition string. If `partition` starts with `persist:`, the page will use a persistent session available to all pages in the app with the same `partition`. If there is no `persist:` prefix, the page will use an in-memory session. By assigning the same `partition`, multiple pages can share the same session. Default is the default session.
+	**/
+	@:optional
+	var partition : String; /**
+		When specified, web pages with the same `affinity` will run in the same renderer process. Note that due to reusing the renderer process, certain `webPreferences` options will also be shared between the web pages even when you specified different values for them, including but not limited to `preload`, `sandbox` and `nodeIntegration`. So it is suggested to use exact same `webPreferences` for web pages with the same `affinity`. _Deprecated_
+	**/
+	@:optional
+	var affinity : String; /**
+		The default zoom factor of the page, `3.0` represents `300%`. Default is `1.0`.
+	**/
+	@:optional
+	var zoomFactor : Float; /**
+		Enables JavaScript support. Default is `true`.
+	**/
+	@:optional
+	var javascript : Bool; /**
+		When `false`, it will disable the same-origin policy (usually using testing websites by people), and set `allowRunningInsecureContent` to `true` if this options has not been set by user. Default is `true`.
+	**/
+	@:optional
+	var webSecurity : Bool; /**
+		Allow an https page to run JavaScript, CSS or plugins from http URLs. Default is `false`.
+	**/
+	@:optional
+	var allowRunningInsecureContent : Bool; /**
+		Enables image support. Default is `true`.
+	**/
+	@:optional
+	var images : Bool; /**
+		Make TextArea elements resizable. Default is `true`.
+	**/
+	@:optional
+	var textAreasAreResizable : Bool; /**
+		Enables WebGL support. Default is `true`.
+	**/
+	@:optional
+	var webgl : Bool; /**
+		Whether plugins should be enabled. Default is `false`.
+	**/
+	@:optional
+	var plugins : Bool; /**
+		Enables Chromium's experimental features. Default is `false`.
+	**/
+	@:optional
+	var experimentalFeatures : Bool; /**
+		Enables scroll bounce (rubber banding) effect on macOS. Default is `false`.
+	**/
+	@:optional
+	var scrollBounce : Bool; /**
+		A list of feature strings separated by `,`, like `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature strings can be found in the RuntimeEnabledFeatures.json5 file.
+	**/
+	@:optional
+	var enableBlinkFeatures : String; /**
+		A list of feature strings separated by `,`, like `CSSVariables,KeyboardEventKey` to disable. The full list of supported feature strings can be found in the RuntimeEnabledFeatures.json5 file.
+	**/
+	@:optional
+	var disableBlinkFeatures : String; /**
+		Sets the default font for the font-family.
+	**/
+	@:optional
+	var defaultFontFamily : { /**
+		Defaults to `Times New Roman`.
+	**/
+	@:optional
+	var standard : String; /**
+		Defaults to `Times New Roman`.
+	**/
+	@:optional
+	var serif : String; /**
+		Defaults to `Arial`.
+	**/
+	@:optional
+	var sansSerif : String; /**
+		Defaults to `Courier New`.
+	**/
+	@:optional
+	var monospace : String; /**
+		Defaults to `Script`.
+	**/
+	@:optional
+	var cursive : String; /**
+		Defaults to `Impact`.
+	**/
+	@:optional
+	var fantasy : String; }; /**
+		Defaults to `16`.
+	**/
+	@:optional
+	var defaultFontSize : Int; /**
+		Defaults to `13`.
+	**/
+	@:optional
+	var defaultMonospaceFontSize : Int; /**
+		Defaults to `0`.
+	**/
+	@:optional
+	var minimumFontSize : Int; /**
+		Defaults to `ISO-8859-1`.
+	**/
+	@:optional
+	var defaultEncoding : String; /**
+		Whether to throttle animations and timers when the page becomes background. This also affects the Page Visibility API. Defaults to `true`.
+	**/
+	@:optional
+	var backgroundThrottling : Bool; /**
+		Whether to enable offscreen rendering for the browser window. Defaults to `false`. See the offscreen rendering tutorial for more details.
+	**/
+	@:optional
+	var offscreen : Bool; /**
+		Whether to run Electron APIs and the specified `preload` script in a separate JavaScript context. Defaults to `false`. The context that the `preload` script runs in will still have full access to the `document` and `window` globals but it will use its own set of JavaScript builtins (`Array`, `Object`, `JSON`, etc.) and will be isolated from any changes made to the global environment by the loaded page. The Electron API will only be available in the `preload` script and not the loaded page. This option should be used when loading potentially untrusted remote content to ensure the loaded content cannot tamper with the `preload` script and any Electron APIs being used. This option uses the same technique used by Chrome Content Scripts. You can access this context in the dev tools by selecting the 'Electron Isolated Context' entry in the combo box at the top of the Console tab.
+	**/
+	@:optional
+	var contextIsolation : Bool; /**
+		If true, values returned from `webFrame.executeJavaScript` will be sanitized to ensure JS values can't unsafely cross between worlds when using `contextIsolation`.  The default is `false`. In Electron 12, the default will be changed to `true`. _Deprecated_
+	**/
+	@:optional
+	var worldSafeExecuteJavaScript : Bool; /**
+		Whether to use native `window.open()`. Defaults to `false`. Child windows will always have node integration disabled unless `nodeIntegrationInSubFrames` is true. **Note:** This option is currently experimental.
+	**/
+	@:optional
+	var nativeWindowOpen : Bool; /**
+		Whether to enable the `<webview>` tag. Defaults to `false`. **Note:** The `preload` script configured for the `<webview>` will have node integration enabled when it is executed so you should ensure remote/untrusted content is not able to create a `<webview>` tag with a possibly malicious `preload` script. You can use the `will-attach-webview` event on webContents to strip away the `preload` script and to validate or alter the `<webview>`'s initial settings.
+	**/
+	@:optional
+	var webviewTag : Bool; /**
+		A list of strings that will be appended to `process.argv` in the renderer process of this app.  Useful for passing small bits of data down to renderer process preload scripts.
+	**/
+	@:optional
+	var additionalArguments : Array<String>; /**
+		Whether to enable browser style consecutive dialog protection. Default is `false`.
+	**/
+	@:optional
+	var safeDialogs : Bool; /**
+		The message to display when consecutive dialog protection is triggered. If not defined the default message would be used, note that currently the default message is in English and not localized.
+	**/
+	@:optional
+	var safeDialogsMessage : String; /**
+		Whether to disable dialogs completely. Overrides `safeDialogs`. Default is `false`.
+	**/
+	@:optional
+	var disableDialogs : Bool; /**
+		Whether dragging and dropping a file or link onto the page causes a navigation. Default is `false`.
+	**/
+	@:optional
+	var navigateOnDragDrop : Bool; /**
+		Autoplay policy to apply to content in the window, can be `no-user-gesture-required`, `user-gesture-required`, `document-user-activation-required`. Defaults to `no-user-gesture-required`.
+	**/
+	@:optional
+	var autoplayPolicy : String; /**
+		Whether to prevent the window from resizing when entering HTML Fullscreen. Default is `false`.
+	**/
+	@:optional
+	var disableHtmlFullscreenWindowResize : Bool; /**
+		An alternative title string provided only to accessibility tools such as screen readers. This string is not directly visible to users.
+	**/
+	@:optional
+	var accessibleTitle : String; /**
+		Whether to enable the builtin spellchecker. Default is `true`.
+	**/
+	@:optional
+	var spellcheck : Bool; /**
+		Whether to enable the WebSQL api. Default is `true`.
+	**/
+	@:optional
+	var enableWebSQL : Bool; /**
+		Enforces the v8 code caching policy used by blink. Accepted values are
+	**/
+	@:optional
+	var v8CacheOptions : String; }; }):Void;
+	/**
+		Force closing the window, the `unload` and `beforeunload` event won't be emitted for the web page, and `close` event will also not be emitted for this window, but it guarantees the `closed` event will be emitted.
+	**/
+	function destroy():Void;
+	/**
+		Try to close the window. This has the same effect as a user manually clicking the close button of the window. The web page may cancel the close though. See the close event.
+	**/
+	function close():Void;
+	/**
+		Focuses on the window.
+	**/
+	function focus():Void;
+	/**
+		Removes focus from the window.
+	**/
+	function blur():Void;
+	/**
+		Whether the window is focused.
+	**/
+	function isFocused():Bool;
+	/**
+		Whether the window is destroyed.
+	**/
+	function isDestroyed():Bool;
+	/**
+		Shows and gives focus to the window.
+	**/
+	function show():Void;
+	/**
+		Shows the window but doesn't focus on it.
+	**/
+	function showInactive():Void;
+	/**
+		Hides the window.
+	**/
+	function hide():Void;
+	/**
+		Whether the window is visible to the user.
+	**/
+	function isVisible():Bool;
+	/**
+		Whether current window is a modal window.
+	**/
+	function isModal():Bool;
+	/**
+		Maximizes the window. This will also show (but not focus) the window if it isn't being displayed already.
+	**/
+	function maximize():Void;
+	/**
+		Unmaximizes the window.
+	**/
+	function unmaximize():Void;
+	/**
+		Whether the window is maximized.
+	**/
+	function isMaximized():Bool;
+	/**
+		Minimizes the window. On some platforms the minimized window will be shown in the Dock.
+	**/
+	function minimize():Void;
+	/**
+		Restores the window from minimized state to its previous state.
+	**/
+	function restore():Void;
+	/**
+		Whether the window is minimized.
+	**/
+	function isMinimized():Bool;
+	/**
+		Sets whether the window should be in fullscreen mode.
+	**/
+	function setFullScreen(flag:Bool):Void;
+	/**
+		Whether the window is in fullscreen mode.
+	**/
+	function isFullScreen():Bool;
+	/**
+		Enters or leaves simple fullscreen mode.
+		
+		Simple fullscreen mode emulates the native fullscreen behavior found in versions of macOS prior to Lion (10.7).
+	**/
+	function setSimpleFullScreen(flag:Bool):Void;
+	/**
+		Whether the window is in simple (pre-Lion) fullscreen mode.
+	**/
+	function isSimpleFullScreen():Bool;
+	/**
+		Whether the window is in normal state (not maximized, not minimized, not in fullscreen mode).
+	**/
+	function isNormal():Bool;
+	/**
+		This will make a window maintain an aspect ratio. The extra size allows a developer to have space, specified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a window's size and its content size.
+		
+		Consider a normal window with an HD video player and associated controls. Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls on the right edge and 50 pixels of controls below the player. In order to maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within the player itself we would call this function with arguments of 16/9 and { width: 40, height: 50 }. The second argument doesn't care where the extra width and height are within the content view--only that they exist. Sum any extra width and height areas you have within the overall content view.
+		
+		The aspect ratio is not respected when window is resized programmingly with APIs like `win.setSize`.
+	**/
+	function setAspectRatio(aspectRatio:Float, ?extraSize:electron.Size):Void;
+	/**
+		Sets the background color of the window. See Setting `backgroundColor`.
+	**/
+	function setBackgroundColor(backgroundColor:String):Void;
+	/**
+		Uses Quick Look to preview a file at a given path.
+	**/
+	function previewFile(path:String, ?displayName:String):Void;
+	/**
+		Closes the currently open Quick Look panel.
+	**/
+	function closeFilePreview():Void;
+	/**
+		Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.
+	**/
+	function setBounds(bounds:Partial, ?animate:Bool):Void;
+	/**
+		The `bounds` of the window as `Object`.
+	**/
+	function getBounds():electron.Rectangle;
+	/**
+		Gets the background color of the window. See Setting `backgroundColor`.
+	**/
+	function getBackgroundColor():String;
+	/**
+		Resizes and moves the window's client area (e.g. the web page) to the supplied bounds.
+	**/
+	function setContentBounds(bounds:electron.Rectangle, ?animate:Bool):Void;
+	/**
+		The `bounds` of the window's client area as `Object`.
+	**/
+	function getContentBounds():electron.Rectangle;
+	/**
+		Contains the window bounds of the normal state
+		
+		**Note:** whatever the current state of the window : maximized, minimized or in fullscreen, this function always returns the position and size of the window in normal state. In normal state, getBounds and getNormalBounds returns the same `Rectangle`.
+	**/
+	function getNormalBounds():electron.Rectangle;
+	/**
+		Disable or enable the window.
+	**/
+	function setEnabled(enable:Bool):Void;
+	/**
+		whether the window is enabled.
+	**/
+	function isEnabled():Bool;
+	/**
+		Resizes the window to `width` and `height`. If `width` or `height` are below any set minimum size constraints the window will snap to its minimum size.
+	**/
+	function setSize(width:Int, height:Int, ?animate:Bool):Void;
+	/**
+		Contains the window's width and height.
+	**/
+	function getSize():Array<Int>;
+	/**
+		Resizes the window's client area (e.g. the web page) to `width` and `height`.
+	**/
+	function setContentSize(width:Int, height:Int, ?animate:Bool):Void;
+	/**
+		Contains the window's client area's width and height.
+	**/
+	function getContentSize():Array<Int>;
+	/**
+		Sets the minimum size of window to `width` and `height`.
+	**/
+	function setMinimumSize(width:Int, height:Int):Void;
+	/**
+		Contains the window's minimum width and height.
+	**/
+	function getMinimumSize():Array<Int>;
+	/**
+		Sets the maximum size of window to `width` and `height`.
+	**/
+	function setMaximumSize(width:Int, height:Int):Void;
+	/**
+		Contains the window's maximum width and height.
+	**/
+	function getMaximumSize():Array<Int>;
+	/**
+		Sets whether the window can be manually resized by the user.
+	**/
+	function setResizable(resizable:Bool):Void;
+	/**
+		Whether the window can be manually resized by the user.
+	**/
+	function isResizable():Bool;
+	/**
+		Sets whether the window can be moved by user. On Linux does nothing.
+	**/
+	function setMovable(movable:Bool):Void;
+	/**
+		Whether the window can be moved by user.
+		
+		On Linux always returns `true`.
+	**/
+	function isMovable():Bool;
+	/**
+		Sets whether the window can be manually minimized by user. On Linux does nothing.
+	**/
+	function setMinimizable(minimizable:Bool):Void;
+	/**
+		Whether the window can be manually minimized by the user.
+		
+		On Linux always returns `true`.
+	**/
+	function isMinimizable():Bool;
+	/**
+		Sets whether the window can be manually maximized by user. On Linux does nothing.
+	**/
+	function setMaximizable(maximizable:Bool):Void;
+	/**
+		Whether the window can be manually maximized by user.
+		
+		On Linux always returns `true`.
+	**/
+	function isMaximizable():Bool;
+	/**
+		Sets whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
+	**/
+	function setFullScreenable(fullscreenable:Bool):Void;
+	/**
+		Whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
+	**/
+	function isFullScreenable():Bool;
+	/**
+		Sets whether the window can be manually closed by user. On Linux does nothing.
+	**/
+	function setClosable(closable:Bool):Void;
+	/**
+		Whether the window can be manually closed by user.
+		
+		On Linux always returns `true`.
+	**/
+	function isClosable():Bool;
+	/**
+		Sets whether the window should show always on top of other windows. After setting this, the window is still a normal window, not a toolbox window which can not be focused on.
+	**/
+	function setAlwaysOnTop(flag:Bool, ?level:String, ?relativeLevel:Int):Void;
+	/**
+		Whether the window is always on top of other windows.
+	**/
+	function isAlwaysOnTop():Bool;
+	/**
+		Moves window above the source window in the sense of z-order. If the `mediaSourceId` is not of type window or if the window does not exist then this method throws an error.
+	**/
+	function moveAbove(mediaSourceId:String):Void;
+	/**
+		Moves window to top(z-order) regardless of focus
+	**/
+	function moveTop():Void;
+	/**
+		Moves window to the center of the screen.
+	**/
+	function center():Void;
+	/**
+		Moves window to `x` and `y`.
+	**/
+	function setPosition(x:Int, y:Int, ?animate:Bool):Void;
+	/**
+		Contains the window's current position.
+	**/
+	function getPosition():Array<Int>;
+	/**
+		Changes the title of native window to `title`.
+	**/
+	function setTitle(title:String):Void;
+	/**
+		The title of the native window.
+		
+		**Note:** The title of the web page can be different from the title of the native window.
+	**/
+	function getTitle():String;
+	/**
+		Changes the attachment point for sheets on macOS. By default, sheets are attached just below the window frame, but you may want to display them beneath a HTML-rendered toolbar. For example:
+	**/
+	function setSheetOffset(offsetY:Float, ?offsetX:Float):Void;
+	/**
+		Starts or stops flashing the window to attract user's attention.
+	**/
+	function flashFrame(flag:Bool):Void;
+	/**
+		Makes the window not show in the taskbar.
+	**/
+	function setSkipTaskbar(skip:Bool):Void;
+	/**
+		Enters or leaves kiosk mode.
+	**/
+	function setKiosk(flag:Bool):Void;
+	/**
+		Whether the window is in kiosk mode.
+	**/
+	function isKiosk():Bool;
+	/**
+		Window id in the format of DesktopCapturerSource's id. For example "window:1234:0".
+		
+		More precisely the format is `window:id:other_id` where `id` is `HWND` on Windows, `CGWindowID` (`uint64_t`) on macOS and `Window` (`unsigned long`) on Linux. `other_id` is used to identify web contents (tabs) so within the same top level window.
+	**/
+	function getMediaSourceId():String;
+	/**
+		The platform-specific handle of the window.
+		
+		The native type of the handle is `HWND` on Windows, `NSView*` on macOS, and `Window` (`unsigned long`) on Linux.
+	**/
+	function getNativeWindowHandle():js.node.Buffer;
+	/**
+		Hooks a windows message. The `callback` is called when the message is received in the WndProc.
+	**/
+	function hookWindowMessage(message:Int, callback:haxe.Constraints.Function):Void;
+	/**
+		`true` or `false` depending on whether the message is hooked.
+	**/
+	function isWindowMessageHooked(message:Int):Bool;
+	/**
+		Unhook the window message.
+	**/
+	function unhookWindowMessage(message:Int):Void;
+	/**
+		Unhooks all of the window messages.
+	**/
+	function unhookAllWindowMessages():Void;
+	/**
+		Sets the pathname of the file the window represents, and the icon of the file will show in window's title bar.
+	**/
+	function setRepresentedFilename(filename:String):Void;
+	/**
+		The pathname of the file the window represents.
+	**/
+	function getRepresentedFilename():String;
+	/**
+		Specifies whether the window’s document has been edited, and the icon in title bar will become gray when set to `true`.
+	**/
+	function setDocumentEdited(edited:Bool):Void;
+	/**
+		Whether the window's document has been edited.
+	**/
+	function isDocumentEdited():Bool;
+	function focusOnWebView():Void;
+	function blurWebView():Void;
+	/**
+		Resolves with a NativeImage
+		
+		Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
+	**/
+	function capturePage(?rect:electron.Rectangle):js.lib.Promise<Any>;
+	/**
+		the promise will resolve when the page has finished loading (see `did-finish-load`), and rejects if the page fails to load (see `did-fail-load`).
+		
+		Same as `webContents.loadURL(url[, options])`.
+		
+		The `url` can be a remote address (e.g. `http://`) or a path to a local HTML file using the `file://` protocol.
+		
+		To ensure that file URLs are properly formatted, it is recommended to use Node's `url.format` method:
+		
+		You can load a URL using a `POST` request with URL-encoded data by doing the following:
+	**/
+	function loadURL(url:String, ?options:{ /**
+		An HTTP Referrer URL.
+	**/
+	@:optional
+	var httpReferrer : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		A user agent originating the request.
+	**/
+	@:optional
+	var userAgent : String; /**
+		Extra headers separated by "\n"
+	**/
+	@:optional
+	var extraHeaders : String; @:optional
+	var postData : haxe.extern.EitherType<Array<Dynamic>, haxe.extern.EitherType<Array<Dynamic>, Array<Dynamic>>>; /**
+		Base URL (with trailing path separator) for files to be loaded by the data URL. This is needed only if the specified `url` is a data URL and needs to load other files.
+	**/
+	@:optional
+	var baseURLForDataURL : String; }):js.lib.Promise<Any>;
+	/**
+		the promise will resolve when the page has finished loading (see `did-finish-load`), and rejects if the page fails to load (see `did-fail-load`).
+		
+		Same as `webContents.loadFile`, `filePath` should be a path to an HTML file relative to the root of your application.  See the `webContents` docs for more information.
+	**/
+	function loadFile(filePath:String, ?options:{ /**
+		Passed to `url.format()`.
+	**/
+	@:optional
+	var query : Record; /**
+		Passed to `url.format()`.
+	**/
+	@:optional
+	var search : String; /**
+		Passed to `url.format()`.
+	**/
+	@:optional
+	var hash : String; }):js.lib.Promise<Any>;
+	/**
+		Same as `webContents.reload`.
+	**/
+	function reload():Void;
+	/**
+		Sets the `menu` as the window's menu bar.
+	**/
+	function setMenu(menu:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Remove the window's menu bar.
+	**/
+	function removeMenu():Void;
+	/**
+		Sets progress value in progress bar. Valid range is [0, 1.0].
+		
+		Remove progress bar when progress < 0; Change to indeterminate mode when progress > 1.
+		
+		On Linux platform, only supports Unity desktop environment, you need to specify the `*.desktop` file name to `desktopName` field in `package.json`. By default, it will assume `{app.name}.desktop`.
+		
+		On Windows, a mode can be passed. Accepted values are `none`, `normal`, `indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a mode set (but with a value within the valid range), `normal` will be assumed.
+	**/
+	function setProgressBar(progress:Float, ?options:{ /**
+		Mode for the progress bar. Can be `none`, `normal`, `indeterminate`, `error` or `paused`.
+	**/
+	var mode : String; }):Void;
+	/**
+		Sets a 16 x 16 pixel overlay onto the current taskbar icon, usually used to convey some sort of application status or to passively notify the user.
+	**/
+	function setOverlayIcon(overlay:haxe.extern.EitherType<Dynamic, Dynamic>, description:String):Void;
+	/**
+		Sets whether the window should have a shadow.
+	**/
+	function setHasShadow(hasShadow:Bool):Void;
+	/**
+		Whether the window has a shadow.
+	**/
+	function hasShadow():Bool;
+	/**
+		Sets the opacity of the window. On Linux, does nothing. Out of bound number values are clamped to the [0, 1] range.
+	**/
+	function setOpacity(opacity:Float):Void;
+	/**
+		between 0.0 (fully transparent) and 1.0 (fully opaque). On Linux, always returns 1.
+	**/
+	function getOpacity():Float;
+	/**
+		Setting a window shape determines the area within the window where the system permits drawing and user interaction. Outside of the given region, no pixels will be drawn and no mouse events will be registered. Mouse events outside of the region will not be received by that window, but will fall through to whatever is behind the window.
+	**/
+	function setShape(rects:Array<electron.Rectangle>):Void;
+	/**
+		Whether the buttons were added successfully
+		
+		Add a thumbnail toolbar with a specified set of buttons to the thumbnail image of a window in a taskbar button layout. Returns a `Boolean` object indicates whether the thumbnail has been added successfully.
+		
+		The number of buttons in thumbnail toolbar should be no greater than 7 due to the limited room. Once you setup the thumbnail toolbar, the toolbar cannot be removed due to the platform's limitation. But you can call the API with an empty array to clean the buttons.
+		
+		The `buttons` is an array of `Button` objects:
+		
+		* `Button` Object
+		  * `icon` NativeImage - The icon showing in thumbnail toolbar.
+		  * `click` Function
+		  * `tooltip` String (optional) - The text of the button's tooltip.
+		  * `flags` String[] (optional) - Control specific states and behaviors of the button. By default, it is `['enabled']`.
+		
+		The `flags` is an array that can include following `String`s:
+		
+		* `enabled` - The button is active and available to the user.
+		* `disabled` - The button is disabled. It is present, but has a visual state indicating it will not respond to user action.
+		* `dismissonclick` - When the button is clicked, the thumbnail window closes immediately.
+		* `nobackground` - Do not draw a button border, use only the image.
+		* `hidden` - The button is not shown to the user.
+		* `noninteractive` - The button is enabled but not interactive; no pressed button state is drawn. This value is intended for instances where the button is used in a notification.
+	**/
+	function setThumbarButtons(buttons:Array<electron.ThumbarButton>):Bool;
+	/**
+		Sets the region of the window to show as the thumbnail image displayed when hovering over the window in the taskbar. You can reset the thumbnail to be the entire window by specifying an empty region: `{ x: 0, y: 0, width: 0, height: 0 }`.
+	**/
+	function setThumbnailClip(region:electron.Rectangle):Void;
+	/**
+		Sets the toolTip that is displayed when hovering over the window thumbnail in the taskbar.
+	**/
+	function setThumbnailToolTip(toolTip:String):Void;
+	/**
+		Sets the properties for the window's taskbar button.
+		
+		**Note:** `relaunchCommand` and `relaunchDisplayName` must always be set together. If one of those properties is not set, then neither will be used.
+	**/
+	function setAppDetails(options:{ /**
+		Window's App User Model ID. It has to be set, otherwise the other options will have no effect.
+	**/
+	@:optional
+	var appId : String; /**
+		Window's Relaunch Icon.
+	**/
+	@:optional
+	var appIconPath : String; /**
+		Index of the icon in `appIconPath`. Ignored when `appIconPath` is not set. Default is `0`.
+	**/
+	@:optional
+	var appIconIndex : Int; /**
+		Window's Relaunch Command.
+	**/
+	@:optional
+	var relaunchCommand : String; /**
+		Window's Relaunch Display Name.
+	**/
+	@:optional
+	var relaunchDisplayName : String; }):Void;
+	/**
+		Same as `webContents.showDefinitionForSelection()`.
+	**/
+	function showDefinitionForSelection():Void;
+	/**
+		Changes window icon.
+	**/
+	function setIcon(icon:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Sets whether the window traffic light buttons should be visible.
+		
+		This cannot be called when `titleBarStyle` is set to `customButtonsOnHover`.
+	**/
+	function setWindowButtonVisibility(visible:Bool):Void;
+	/**
+		Sets whether the window menu bar should hide itself automatically. Once set the menu bar will only show when users press the single `Alt` key.
+		
+		If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't hide it immediately.
+	**/
+	function setAutoHideMenuBar(hide:Bool):Void;
+	/**
+		Whether menu bar automatically hides itself.
+	**/
+	function isMenuBarAutoHide():Bool;
+	/**
+		Sets whether the menu bar should be visible. If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
+	**/
+	function setMenuBarVisibility(visible:Bool):Void;
+	/**
+		Whether the menu bar is visible.
+	**/
+	function isMenuBarVisible():Bool;
+	/**
+		Sets whether the window should be visible on all workspaces.
+		
+		**Note:** This API does nothing on Windows.
+	**/
+	function setVisibleOnAllWorkspaces(visible:Bool, ?options:{ /**
+		Sets whether the window should be visible above fullscreen windows
+	**/
+	@:optional
+	var visibleOnFullScreen : Bool; }):Void;
+	/**
+		Whether the window is visible on all workspaces.
+		
+		**Note:** This API always returns false on Windows.
+	**/
+	function isVisibleOnAllWorkspaces():Bool;
+	/**
+		Makes the window ignore all mouse events.
+		
+		All mouse events happened in this window will be passed to the window below this window, but if this window has focus, it will still receive keyboard events.
+	**/
+	function setIgnoreMouseEvents(ignore:Bool, ?options:{ /**
+		If true, forwards mouse move messages to Chromium, enabling mouse related events such as `mouseleave`. Only used when `ignore` is true. If `ignore` is false, forwarding is always disabled regardless of this value.
+	**/
+	@:optional
+	var forward : Bool; }):Void;
+	/**
+		Prevents the window contents from being captured by other apps.
+		
+		On macOS it sets the NSWindow's sharingType to NSWindowSharingNone. On Windows it calls SetWindowDisplayAffinity with `WDA_MONITOR`.
+	**/
+	function setContentProtection(enable:Bool):Void;
+	/**
+		Changes whether the window can be focused.
+		
+		On macOS it does not remove the focus from the window.
+	**/
+	function setFocusable(focusable:Bool):Void;
+	/**
+		Sets `parent` as current window's parent window, passing `null` will turn current window into a top-level window.
+	**/
+	function setParentWindow(parent:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The parent window.
+	**/
+	function getParentWindow():electron.main.BrowserWindow;
+	/**
+		All child windows.
+	**/
+	function getChildWindows():Array<electron.main.BrowserWindow>;
+	/**
+		Controls whether to hide cursor when typing.
+	**/
+	function setAutoHideCursor(autoHide:Bool):Void;
+	/**
+		Selects the previous tab when native tabs are enabled and there are other tabs in the window.
+	**/
+	function selectPreviousTab():Void;
+	/**
+		Selects the next tab when native tabs are enabled and there are other tabs in the window.
+	**/
+	function selectNextTab():Void;
+	/**
+		Merges all windows into one window with multiple tabs when native tabs are enabled and there is more than one open window.
+	**/
+	function mergeAllWindows():Void;
+	/**
+		Moves the current tab into a new window if native tabs are enabled and there is more than one tab in the current window.
+	**/
+	function moveTabToNewWindow():Void;
+	/**
+		Toggles the visibility of the tab bar if native tabs are enabled and there is only one tab in the current window.
+	**/
+	function toggleTabBar():Void;
+	/**
+		Adds a window as a tab on this window, after the tab for the window instance.
+	**/
+	function addTabbedWindow(browserWindow:electron.main.BrowserWindow):Void;
+	/**
+		Adds a vibrancy effect to the browser window. Passing `null` or an empty string will remove the vibrancy effect on the window.
+		
+		Note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been deprecated and will be removed in an upcoming version of macOS.
+	**/
+	function setVibrancy(type:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Set a custom position for the traffic light buttons. Can only be used with `titleBarStyle` set to `hidden`.
+	**/
+	function setTrafficLightPosition(position:electron.Point):Void;
+	/**
+		The current position for the traffic light buttons. Can only be used with `titleBarStyle` set to `hidden`.
+	**/
+	function getTrafficLightPosition():electron.Point;
+	/**
+		Sets the touchBar layout for the current window. Specifying `null` or `undefined` clears the touch bar. This method only has an effect if the machine has a touch bar and is running on macOS 10.12.1+.
+		
+		**Note:** The TouchBar API is currently experimental and may change or be removed in future Electron releases.
+	**/
+	function setTouchBar(touchBar:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	function setBrowserView(browserView:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `BrowserView` attached to `win`. Returns `null` if one is not attached. Throws an error if multiple `BrowserView`s are attached.
+	**/
+	function getBrowserView():haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		Replacement API for setBrowserView supporting work with multi browser views.
+	**/
+	function addBrowserView(browserView:electron.main.BrowserView):Void;
+	function removeBrowserView(browserView:electron.main.BrowserView):Void;
+	/**
+		an array of all BrowserViews that have been attached with `addBrowserView` or `setBrowserView`.
+		
+		**Note:** The BrowserView API is currently experimental and may change or be removed in future Electron releases.
+	**/
+	function getBrowserViews():Array<electron.main.BrowserView>;
+}
+@:enum abstract BrowserWindowEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the document changed its title, calling `event.preventDefault()` will prevent the native window's title from changing. `explicitSet` is false when title is synthesized from file URL.
+	**/
+	var page_title_updated : electron.main.BrowserWindowEvent<Void -> Void> = "page-title-updated";
+	/**
+		Emitted when the window is going to be closed. It's emitted before the `beforeunload` and `unload` event of the DOM. Calling `event.preventDefault()` will cancel the close.
+		
+		Usually you would want to use the `beforeunload` handler to decide whether the window should be closed, which will also be called when the window is reloaded. In Electron, returning any value other than `undefined` would cancel the close. For example:
+		
+		_**Note**: There is a subtle difference between the behaviors of `window.onbeforeunload = handler` and `window.addEventListener('beforeunload', handler)`. It is recommended to always set the `event.returnValue` explicitly, instead of only returning a value, as the former works more consistently within Electron._
+	**/
+	var close : electron.main.BrowserWindowEvent<Void -> Void> = "close";
+	/**
+		Emitted when the window is closed. After you have received this event you should remove the reference to the window and avoid using it any more.
+	**/
+	var closed : electron.main.BrowserWindowEvent<Void -> Void> = "closed";
+	/**
+		Emitted when window session is going to end due to force shutdown or machine restart or session log off.
+	**/
+	var session_end : electron.main.BrowserWindowEvent<Void -> Void> = "session-end";
+	/**
+		Emitted when the web page becomes unresponsive.
+	**/
+	var unresponsive : electron.main.BrowserWindowEvent<Void -> Void> = "unresponsive";
+	/**
+		Emitted when the unresponsive web page becomes responsive again.
+	**/
+	var responsive : electron.main.BrowserWindowEvent<Void -> Void> = "responsive";
+	/**
+		Emitted when the window loses focus.
+	**/
+	var blur : electron.main.BrowserWindowEvent<Void -> Void> = "blur";
+	/**
+		Emitted when the window gains focus.
+	**/
+	var focus : electron.main.BrowserWindowEvent<Void -> Void> = "focus";
+	/**
+		Emitted when the window is shown.
+	**/
+	var show : electron.main.BrowserWindowEvent<Void -> Void> = "show";
+	/**
+		Emitted when the window is hidden.
+	**/
+	var hide : electron.main.BrowserWindowEvent<Void -> Void> = "hide";
+	/**
+		Emitted when the web page has been rendered (while not being shown) and window can be displayed without a visual flash.
+		
+		Please note that using this event implies that the renderer will be considered "visible" and paint even though `show` is false.  This event will never fire if you use `paintWhenInitiallyHidden: false`
+	**/
+	var ready_to_show : electron.main.BrowserWindowEvent<Void -> Void> = "ready-to-show";
+	/**
+		Emitted when window is maximized.
+	**/
+	var maximize : electron.main.BrowserWindowEvent<Void -> Void> = "maximize";
+	/**
+		Emitted when the window exits from a maximized state.
+	**/
+	var unmaximize : electron.main.BrowserWindowEvent<Void -> Void> = "unmaximize";
+	/**
+		Emitted when the window is minimized.
+	**/
+	var minimize : electron.main.BrowserWindowEvent<Void -> Void> = "minimize";
+	/**
+		Emitted when the window is restored from a minimized state.
+	**/
+	var restore : electron.main.BrowserWindowEvent<Void -> Void> = "restore";
+	/**
+		Emitted before the window is resized. Calling `event.preventDefault()` will prevent the window from being resized.
+		
+		Note that this is only emitted when the window is being resized manually. Resizing the window with `setBounds`/`setSize` will not emit this event.
+	**/
+	var will_resize : electron.main.BrowserWindowEvent<Void -> Void> = "will-resize";
+	/**
+		Emitted after the window has been resized.
+	**/
+	var resize : electron.main.BrowserWindowEvent<Void -> Void> = "resize";
+	/**
+		Emitted once when the window has finished being resized.
+		
+		This is usually emitted when the window has been resized manually. On macOS, resizing the window with `setBounds`/`setSize` and setting the `animate` parameter to `true` will also emit this event once resizing has finished.
+	**/
+	var resized : electron.main.BrowserWindowEvent<Void -> Void> = "resized";
+	/**
+		Emitted before the window is moved. On Windows, calling `event.preventDefault()` will prevent the window from being moved.
+		
+		Note that this is only emitted when the window is being resized manually. Resizing the window with `setBounds`/`setSize` will not emit this event.
+	**/
+	var will_move : electron.main.BrowserWindowEvent<Void -> Void> = "will-move";
+	/**
+		Emitted when the window is being moved to a new position.
+	**/
+	var move : electron.main.BrowserWindowEvent<Void -> Void> = "move";
+	/**
+		Emitted once when the window is moved to a new position.
+		
+		__Note__: On macOS this event is an alias of `move`.
+	**/
+	var moved : electron.main.BrowserWindowEvent<Void -> Void> = "moved";
+	/**
+		Emitted when the window enters a full-screen state.
+	**/
+	var enter_full_screen : electron.main.BrowserWindowEvent<Void -> Void> = "enter-full-screen";
+	/**
+		Emitted when the window leaves a full-screen state.
+	**/
+	var leave_full_screen : electron.main.BrowserWindowEvent<Void -> Void> = "leave-full-screen";
+	/**
+		Emitted when the window enters a full-screen state triggered by HTML API.
+	**/
+	var enter_html_full_screen : electron.main.BrowserWindowEvent<Void -> Void> = "enter-html-full-screen";
+	/**
+		Emitted when the window leaves a full-screen state triggered by HTML API.
+	**/
+	var leave_html_full_screen : electron.main.BrowserWindowEvent<Void -> Void> = "leave-html-full-screen";
+	/**
+		Emitted when the window is set or unset to show always on top of other windows.
+	**/
+	var always_on_top_changed : electron.main.BrowserWindowEvent<Void -> Void> = "always-on-top-changed";
+	/**
+		Emitted when an App Command is invoked. These are typically related to keyboard media keys or browser commands, as well as the "Back" button built into some mice on Windows.
+		
+		Commands are lowercased, underscores are replaced with hyphens, and the `APPCOMMAND_` prefix is stripped off. e.g. `APPCOMMAND_BROWSER_BACKWARD` is emitted as `browser-backward`.
+		
+		The following app commands are explicitly supported on Linux:
+		
+		* `browser-backward`
+		* `browser-forward`
+	**/
+	var app_command : electron.main.BrowserWindowEvent<Void -> Void> = "app-command";
+	/**
+		Emitted when scroll wheel event phase has begun.
+	**/
+	var scroll_touch_begin : electron.main.BrowserWindowEvent<Void -> Void> = "scroll-touch-begin";
+	/**
+		Emitted when scroll wheel event phase has ended.
+	**/
+	var scroll_touch_end : electron.main.BrowserWindowEvent<Void -> Void> = "scroll-touch-end";
+	/**
+		Emitted when scroll wheel event phase filed upon reaching the edge of element.
+	**/
+	var scroll_touch_edge : electron.main.BrowserWindowEvent<Void -> Void> = "scroll-touch-edge";
+	/**
+		Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
+		
+		The method underlying this event is built to handle older macOS-style trackpad swiping, where the content on the screen doesn't move with the swipe. Most macOS trackpads are not configured to allow this kind of swiping anymore, so in order for it to emit properly the 'Swipe between pages' preference in `System Preferences > Trackpad > More Gestures` must be set to 'Swipe with two or three fingers'.
+	**/
+	var swipe : electron.main.BrowserWindowEvent<Void -> Void> = "swipe";
+	/**
+		Emitted on trackpad rotation gesture. Continually emitted until rotation gesture is ended. The `rotation` value on each emission is the angle in degrees rotated since the last emission. The last emitted event upon a rotation gesture will always be of value `0`. Counter-clockwise rotation values are positive, while clockwise ones are negative.
+	**/
+	var rotate_gesture : electron.main.BrowserWindowEvent<Void -> Void> = "rotate-gesture";
+	/**
+		Emitted when the window opens a sheet.
+	**/
+	var sheet_begin : electron.main.BrowserWindowEvent<Void -> Void> = "sheet-begin";
+	/**
+		Emitted when the window has closed a sheet.
+	**/
+	var sheet_end : electron.main.BrowserWindowEvent<Void -> Void> = "sheet-end";
+	/**
+		Emitted when the native new tab button is clicked.
+	**/
+	var new_window_for_tab : electron.main.BrowserWindowEvent<Void -> Void> = "new-window-for-tab";
+	/**
+		Emitted when the system context menu is triggered on the window, this is normally only triggered when the user right clicks on the non-client area of your window.  This is the window titlebar or any area you have declared as `-webkit-app-region: drag` in a frameless window.
+		
+		Calling `event.preventDefault()` will prevent the menu from being displayed.
+	**/
+	var system_context_menu : electron.main.BrowserWindowEvent<Void -> Void> = "system-context-menu";
+}

--- a/src/electron/remote/ClientRequest.hx
+++ b/src/electron/remote/ClientRequest.hx
@@ -1,0 +1,103 @@
+package electron.remote;
+/**
+	> Make HTTP/HTTPS requests.
+	
+	Process: Main
+	
+	`ClientRequest` implements the Writable Stream interface and is therefore an EventEmitter.
+	@see https://electronjs.org/docs/api/client-request
+**/
+@:jsRequire("electron", "remote.ClientRequest") extern class ClientRequest extends js.node.events.EventEmitter<electron.main.ClientRequest> {
+	/**
+		A `Boolean` specifying whether the request will use HTTP chunked transfer encoding or not. Defaults to false. The property is readable and writable, however it can be set only before the first write operation as the HTTP headers are not yet put on the wire. Trying to set the `chunkedEncoding` property after the first write will throw an error.
+		
+		Using chunked encoding is strongly recommended if you need to send a large request body as data will be streamed in small chunks instead of being internally buffered inside Electron process memory.
+	**/
+	var chunkedEncoding : Bool;
+	function new(options:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Adds an extra HTTP header. The header name will be issued as-is without lowercasing. It can be called only before first write. Calling this method after the first write will throw an error. If the passed value is not a `String`, its `toString()` method will be called to obtain the final value.
+		
+		Certain headers are restricted from being set by apps. These headers are listed below. More information on restricted headers can be found in Chromium's header utils.
+		
+		* `Content-Length`
+		* `Host`
+		* `Trailer` or `Te`
+		* `Upgrade`
+		* `Cookie2`
+		* `Keep-Alive`
+		* `Transfer-Encoding`
+		
+		Additionally, setting the `Connection` header to the value `upgrade` is also disallowed.
+	**/
+	function setHeader(name:String, value:String):Void;
+	/**
+		The value of a previously set extra header name.
+	**/
+	function getHeader(name:String):String;
+	/**
+		Removes a previously set extra header name. This method can be called only before first write. Trying to call it after the first write will throw an error.
+	**/
+	function removeHeader(name:String):Void;
+	/**
+		`callback` is essentially a dummy function introduced in the purpose of keeping similarity with the Node.js API. It is called asynchronously in the next tick after `chunk` content have been delivered to the Chromium networking layer. Contrary to the Node.js implementation, it is not guaranteed that `chunk` content have been flushed on the wire before `callback` is called.
+		
+		Adds a chunk of data to the request body. The first write operation may cause the request headers to be issued on the wire. After the first write operation, it is not allowed to add or remove a custom header.
+	**/
+	function write(chunk:haxe.extern.EitherType<Dynamic, Dynamic>, ?encoding:String, ?callback:haxe.Constraints.Function):Void;
+	/**
+		Sends the last chunk of the request data. Subsequent write or end operations will not be allowed. The `finish` event is emitted just after the end operation.
+	**/
+	function end(?chunk:haxe.extern.EitherType<Dynamic, Dynamic>, ?encoding:String, ?callback:haxe.Constraints.Function):Void;
+	/**
+		Cancels an ongoing HTTP transaction. If the request has already emitted the `close` event, the abort operation will have no effect. Otherwise an ongoing event will emit `abort` and `close` events. Additionally, if there is an ongoing response object,it will emit the `aborted` event.
+	**/
+	function abort():Void;
+	/**
+		Continues any pending redirection. Can only be called during a `'redirect'` event.
+	**/
+	function followRedirect():Void;
+	/**
+		* `active` Boolean - Whether the request is currently active. If this is false no other properties will be set
+		* `started` Boolean - Whether the upload has started. If this is false both `current` and `total` will be set to 0.
+		* `current` Integer - The number of bytes that have been uploaded so far
+		* `total` Integer - The number of bytes that will be uploaded this request
+		
+		You can use this method in conjunction with `POST` requests to get the progress of a file upload or other data transfer.
+	**/
+	function getUploadProgress():Any;
+}
+@:enum abstract ClientRequestEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	var response : electron.main.ClientRequestEvent<Void -> Void> = "response";
+	/**
+		Emitted when an authenticating proxy is asking for user credentials.
+		
+		The `callback` function is expected to be called back with user credentials:
+		
+		* `username` String
+		* `password` String
+		
+		Providing empty credentials will cancel the request and report an authentication error on the response object:
+	**/
+	var login : electron.main.ClientRequestEvent<Void -> Void> = "login";
+	/**
+		Emitted just after the last chunk of the `request`'s data has been written into the `request` object.
+	**/
+	var finish : electron.main.ClientRequestEvent<Void -> Void> = "finish";
+	/**
+		Emitted when the `request` is aborted. The `abort` event will not be fired if the `request` is already closed.
+	**/
+	var abort : electron.main.ClientRequestEvent<Void -> Void> = "abort";
+	/**
+		Emitted when the `net` module fails to issue a network request. Typically when the `request` object emits an `error` event, a `close` event will subsequently follow and no response object will be provided.
+	**/
+	var error : electron.main.ClientRequestEvent<Void -> Void> = "error";
+	/**
+		Emitted as the last event in the HTTP request-response transaction. The `close` event indicates that no more events will be emitted on either the `request` or `response` objects.
+	**/
+	var close : electron.main.ClientRequestEvent<Void -> Void> = "close";
+	/**
+		Emitted when the server returns a redirect response (e.g. 301 Moved Permanently). Calling `request.followRedirect` will continue with the redirection.  If this event is handled, `request.followRedirect` must be called **synchronously**, otherwise the request will be cancelled.
+	**/
+	var redirect : electron.main.ClientRequestEvent<Void -> Void> = "redirect";
+}

--- a/src/electron/remote/CommandLine.hx
+++ b/src/electron/remote/CommandLine.hx
@@ -1,0 +1,33 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/command-line
+**/
+@:jsRequire("electron", "remote.CommandLine") extern class CommandLine extends js.node.events.EventEmitter<electron.main.CommandLine> {
+	/**
+		Append a switch (with optional `value`) to Chromium's command line.
+		
+		**Note:** This will not affect `process.argv`. The intended usage of this function is to control Chromium's behavior.
+	**/
+	function appendSwitch(switch_:String, ?value:String):Void;
+	/**
+		Append an argument to Chromium's command line. The argument will be quoted correctly. Switches will precede arguments regardless of appending order.
+		
+		If you're appending an argument like `--switch=value`, consider using `appendSwitch('switch', 'value')` instead.
+		
+		**Note:** This will not affect `process.argv`. The intended usage of this function is to control Chromium's behavior.
+	**/
+	function appendArgument(value:String):Void;
+	/**
+		Whether the command-line switch is present.
+	**/
+	function hasSwitch(switch_:String):Bool;
+	/**
+		The command-line switch value.
+		
+		**Note:** When the switch is not present or has no value, it returns empty string.
+	**/
+	function getSwitchValue(switch_:String):String;
+}
+@:enum abstract CommandLineEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/ContentTracing.hx
+++ b/src/electron/remote/ContentTracing.hx
@@ -1,0 +1,53 @@
+package electron.remote;
+/**
+	> Collect tracing data from Chromium to find performance bottlenecks and slow operations.
+	
+	Process: Main
+	
+	This module does not include a web interface. To view recorded traces, use trace viewer, available at `chrome://tracing` in Chrome.
+	
+	**Note:** You should not use this module until the `ready` event of the app module is emitted.
+	@see https://electronjs.org/docs/api/content-tracing
+**/
+@:jsRequire("electron", "remote.contentTracing") extern class ContentTracing extends js.node.events.EventEmitter<electron.main.ContentTracing> {
+	/**
+		resolves with an array of category groups once all child processes have acknowledged the `getCategories` request
+		
+		Get a set of category groups. The category groups can change as new code paths are reached. See also the list of built-in tracing categories.
+		
+		> **NOTE:** Electron adds a non-default tracing category called `"electron"`. This category can be used to capture Electron-specific tracing events.
+	**/
+	static function getCategories():js.lib.Promise<Any>;
+	/**
+		resolved once all child processes have acknowledged the `startRecording` request.
+		
+		Start recording on all processes.
+		
+		Recording begins immediately locally and asynchronously on child processes as soon as they receive the EnableRecording request.
+		
+		If a recording is already running, the promise will be immediately resolved, as only one trace operation can be in progress at a time.
+	**/
+	static function startRecording(options:haxe.extern.EitherType<Dynamic, Dynamic>):js.lib.Promise<Any>;
+	/**
+		resolves with a path to a file that contains the traced data once all child processes have acknowledged the `stopRecording` request
+		
+		Stop recording on all processes.
+		
+		Child processes typically cache trace data and only rarely flush and send trace data back to the main process. This helps to minimize the runtime overhead of tracing since sending trace data over IPC can be an expensive operation. So, to end tracing, Chromium asynchronously asks all child processes to flush any pending trace data.
+		
+		Trace data will be written into `resultFilePath`. If `resultFilePath` is empty or not provided, trace data will be written to a temporary file, and the path will be returned in the promise.
+	**/
+	static function stopRecording(?resultFilePath:String):js.lib.Promise<Any>;
+	/**
+		Resolves with an object containing the `value` and `percentage` of trace buffer maximum usage
+		
+		* `value` Number
+		* `percentage` Number
+		
+		Get the maximum usage across processes of trace buffer as a percentage of the full state.
+	**/
+	static function getTraceBufferUsage():js.lib.Promise<Any>;
+}
+@:enum abstract ContentTracingEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Cookies.hx
+++ b/src/electron/remote/Cookies.hx
@@ -1,0 +1,95 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/cookies
+**/
+@:jsRequire("electron", "remote.Cookies") extern class Cookies extends js.node.events.EventEmitter<electron.main.Cookies> {
+	/**
+		A promise which resolves an array of cookie objects.
+		
+		Sends a request to get all cookies matching `filter`, and resolves a promise with the response.
+	**/
+	function get(filter:{ /**
+		Retrieves cookies which are associated with `url`. Empty implies retrieving cookies of all URLs.
+	**/
+	@:optional
+	var url : String; /**
+		Filters cookies by name.
+	**/
+	@:optional
+	var name : String; /**
+		Retrieves cookies whose domains match or are subdomains of `domains`.
+	**/
+	@:optional
+	var domain : String; /**
+		Retrieves cookies whose path matches `path`.
+	**/
+	@:optional
+	var path : String; /**
+		Filters cookies by their Secure property.
+	**/
+	@:optional
+	var secure : Bool; /**
+		Filters out session or persistent cookies.
+	**/
+	@:optional
+	var session : Bool; }):js.lib.Promise<Any>;
+	/**
+		A promise which resolves when the cookie has been set
+		
+		Sets a cookie with `details`.
+	**/
+	function set(details:{ /**
+		The URL to associate the cookie with. The promise will be rejected if the URL is invalid.
+	**/
+	var url : String; /**
+		The name of the cookie. Empty by default if omitted.
+	**/
+	@:optional
+	var name : String; /**
+		The value of the cookie. Empty by default if omitted.
+	**/
+	@:optional
+	var value : String; /**
+		The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.
+	**/
+	@:optional
+	var domain : String; /**
+		The path of the cookie. Empty by default if omitted.
+	**/
+	@:optional
+	var path : String; /**
+		Whether the cookie should be marked as Secure. Defaults to false.
+	**/
+	@:optional
+	var secure : Bool; /**
+		Whether the cookie should be marked as HTTP only. Defaults to false.
+	**/
+	@:optional
+	var httpOnly : Bool; /**
+		The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted then the cookie becomes a session cookie and will not be retained between sessions.
+	**/
+	@:optional
+	var expirationDate : Float; /**
+		The Same Site policy to apply to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.  Default is `no_restriction`.
+	**/
+	@:optional
+	var sameSite : String; }):js.lib.Promise<Any>;
+	/**
+		A promise which resolves when the cookie has been removed
+		
+		Removes the cookies matching `url` and `name`
+	**/
+	function remove(url:String, name:String):js.lib.Promise<Any>;
+	/**
+		A promise which resolves when the cookie store has been flushed
+		
+		Writes any unwritten cookies data to disk.
+	**/
+	function flushStore():js.lib.Promise<Any>;
+}
+@:enum abstract CookiesEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when a cookie is changed because it was added, edited, removed, or expired.
+	**/
+	var changed : electron.main.CookiesEvent<Void -> Void> = "changed";
+}

--- a/src/electron/remote/Debugger.hx
+++ b/src/electron/remote/Debugger.hx
@@ -1,0 +1,34 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/debugger
+**/
+@:jsRequire("electron", "remote.Debugger") extern class Debugger extends js.node.events.EventEmitter<electron.main.Debugger> {
+	/**
+		Attaches the debugger to the `webContents`.
+	**/
+	function attach(?protocolVersion:String):Void;
+	/**
+		Whether a debugger is attached to the `webContents`.
+	**/
+	function isAttached():Bool;
+	/**
+		Detaches the debugger from the `webContents`.
+	**/
+	function detach():Void;
+	/**
+		A promise that resolves with the response defined by the 'returns' attribute of the command description in the remote debugging protocol or is rejected indicating the failure of the command.
+		
+		Send given command to the debugging target.
+	**/
+	function sendCommand(method:String, ?commandParams:Any, ?sessionId:String):js.lib.Promise<Any>;
+}
+@:enum abstract DebuggerEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the debugging session is terminated. This happens either when `webContents` is closed or devtools is invoked for the attached `webContents`.
+	**/
+	var detach : electron.main.DebuggerEvent<Void -> Void> = "detach";
+	/**
+		Emitted whenever the debugging target issues an instrumentation event.
+	**/
+	var message : electron.main.DebuggerEvent<Void -> Void> = "message";
+}

--- a/src/electron/remote/Dialog.hx
+++ b/src/electron/remote/Dialog.hx
@@ -1,0 +1,293 @@
+package electron.remote;
+/**
+	> Display native system dialogs for opening and saving files, alerting, etc.
+	
+	Process: Main
+	
+	An example of showing a dialog to select multiple files:
+	
+	```
+	const { dialog } = require('electron')
+	console.log(dialog.showOpenDialog({ properties: ['openFile', 'multiSelections'] }))
+	```
+	
+	The Dialog is opened from Electron's main thread. If you want to use the dialog object from a renderer process, remember to access it using the remote:
+	@see https://electronjs.org/docs/api/dialog
+**/
+@:jsRequire("electron", "remote.dialog") extern class Dialog extends js.node.events.EventEmitter<electron.main.Dialog> {
+	/**
+		the file paths chosen by the user; if the dialog is cancelled it returns `undefined`.
+		
+		The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+		
+		The `filters` specifies an array of file types that can be displayed or selected when you want to limit the user to a specific type. For example:
+		
+		The `extensions` array should contain extensions without wildcards or dots (e.g. `'png'` is good but `'.png'` and `'*.png'` are bad). To show all files, use the `'*'` wildcard (no other wildcard is supported).
+		
+		**Note:** On Windows and Linux an open dialog can not be both a file selector and a directory selector, so if you set `properties` to `['openFile', 'openDirectory']` on these platforms, a directory selector will be shown.
+	**/
+	static function showOpenDialogSync(?browserWindow:electron.main.BrowserWindow, options:{ @:optional
+	var title : String; @:optional
+	var defaultPath : String; /**
+		Custom label for the confirmation button, when left empty the default label will be used.
+	**/
+	@:optional
+	var buttonLabel : String; @:optional
+	var filters : Array<electron.FileFilter>; /**
+		Contains which features the dialog should use. The following values are supported:
+	**/
+	@:optional
+	var properties : Array<String>; /**
+		Message to display above input boxes.
+	**/
+	@:optional
+	var message : String; /**
+		Create security scoped bookmarks when packaged for the Mac App Store.
+	**/
+	@:optional
+	var securityScopedBookmarks : Bool; }):haxe.extern.EitherType<Array<Dynamic>, Dynamic>;
+	/**
+		Resolve with an object containing the following:
+		
+		* `canceled` Boolean - whether or not the dialog was canceled.
+		* `filePaths` String[] - An array of file paths chosen by the user. If the dialog is cancelled this will be an empty array.
+		* `bookmarks` String[] (optional) _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated. (For return values, see table here.)
+		
+		The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+		
+		The `filters` specifies an array of file types that can be displayed or selected when you want to limit the user to a specific type. For example:
+		
+		The `extensions` array should contain extensions without wildcards or dots (e.g. `'png'` is good but `'.png'` and `'*.png'` are bad). To show all files, use the `'*'` wildcard (no other wildcard is supported).
+		
+		**Note:** On Windows and Linux an open dialog can not be both a file selector and a directory selector, so if you set `properties` to `['openFile', 'openDirectory']` on these platforms, a directory selector will be shown.
+	**/
+	static function showOpenDialog(?browserWindow:electron.main.BrowserWindow, options:{ @:optional
+	var title : String; @:optional
+	var defaultPath : String; /**
+		Custom label for the confirmation button, when left empty the default label will be used.
+	**/
+	@:optional
+	var buttonLabel : String; @:optional
+	var filters : Array<electron.FileFilter>; /**
+		Contains which features the dialog should use. The following values are supported:
+	**/
+	@:optional
+	var properties : Array<String>; /**
+		Message to display above input boxes.
+	**/
+	@:optional
+	var message : String; /**
+		Create security scoped bookmarks when packaged for the Mac App Store.
+	**/
+	@:optional
+	var securityScopedBookmarks : Bool; }):js.lib.Promise<Any>;
+	/**
+		the path of the file chosen by the user; if the dialog is cancelled it returns `undefined`.
+		
+		The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+		
+		The `filters` specifies an array of file types that can be displayed, see `dialog.showOpenDialog` for an example.
+	**/
+	static function showSaveDialogSync(?browserWindow:electron.main.BrowserWindow, options:{ @:optional
+	var title : String; /**
+		Absolute directory path, absolute file path, or file name to use by default.
+	**/
+	@:optional
+	var defaultPath : String; /**
+		Custom label for the confirmation button, when left empty the default label will be used.
+	**/
+	@:optional
+	var buttonLabel : String; @:optional
+	var filters : Array<electron.FileFilter>; /**
+		Message to display above text fields.
+	**/
+	@:optional
+	var message : String; /**
+		Custom label for the text displayed in front of the filename text field.
+	**/
+	@:optional
+	var nameFieldLabel : String; /**
+		Show the tags input box, defaults to `true`.
+	**/
+	@:optional
+	var showsTagField : Bool; @:optional
+	var properties : Array<String>; /**
+		Create a security scoped bookmark when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
+	**/
+	@:optional
+	var securityScopedBookmarks : Bool; }):haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		Resolve with an object containing the following:
+		
+		* `canceled` Boolean - whether or not the dialog was canceled.
+		* `filePath` String (optional) - If the dialog is canceled, this will be `undefined`.
+		* `bookmark` String (optional) _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present. (For return values, see table here.)
+		
+		The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+		
+		The `filters` specifies an array of file types that can be displayed, see `dialog.showOpenDialog` for an example.
+		
+		**Note:** On macOS, using the asynchronous version is recommended to avoid issues when expanding and collapsing the dialog.
+	**/
+	static function showSaveDialog(?browserWindow:electron.main.BrowserWindow, options:{ @:optional
+	var title : String; /**
+		Absolute directory path, absolute file path, or file name to use by default.
+	**/
+	@:optional
+	var defaultPath : String; /**
+		Custom label for the confirmation button, when left empty the default label will be used.
+	**/
+	@:optional
+	var buttonLabel : String; @:optional
+	var filters : Array<electron.FileFilter>; /**
+		Message to display above text fields.
+	**/
+	@:optional
+	var message : String; /**
+		Custom label for the text displayed in front of the filename text field.
+	**/
+	@:optional
+	var nameFieldLabel : String; /**
+		Show the tags input box, defaults to `true`.
+	**/
+	@:optional
+	var showsTagField : Bool; @:optional
+	var properties : Array<String>; /**
+		Create a security scoped bookmark when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
+	**/
+	@:optional
+	var securityScopedBookmarks : Bool; }):js.lib.Promise<Any>;
+	/**
+		the index of the clicked button.
+		
+		Shows a message box, it will block the process until the message box is closed. It returns the index of the clicked button.
+		
+		The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal. If `browserWindow` is not shown dialog will not be attached to it. In such case it will be displayed as an independent window.
+	**/
+	static function showMessageBoxSync(?browserWindow:electron.main.BrowserWindow, options:{ /**
+		Can be `"none"`, `"info"`, `"error"`, `"question"` or `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless you set an icon using the `"icon"` option. On macOS, both `"warning"` and `"error"` display the same warning icon.
+	**/
+	@:optional
+	var type : String; /**
+		Array of texts for buttons. On Windows, an empty array will result in one button labeled "OK".
+	**/
+	@:optional
+	var buttons : Array<String>; /**
+		Index of the button in the buttons array which will be selected by default when the message box opens.
+	**/
+	@:optional
+	var defaultId : Int; /**
+		Title of the message box, some platforms will not show it.
+	**/
+	@:optional
+	var title : String; /**
+		Content of the message box.
+	**/
+	var message : String; /**
+		Extra information of the message.
+	**/
+	@:optional
+	var detail : String; /**
+		If provided, the message box will include a checkbox with the given label.
+	**/
+	@:optional
+	var checkboxLabel : String; /**
+		Initial checked state of the checkbox. `false` by default.
+	**/
+	@:optional
+	var checkboxChecked : Bool; @:optional
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		The index of the button to be used to cancel the dialog, via the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the label. If no such labeled buttons exist and this option is not set, `0` will be used as the return value.
+	**/
+	@:optional
+	var cancelId : Int; /**
+		On Windows Electron will try to figure out which one of the `buttons` are common buttons (like "Cancel" or "Yes"), and show the others as command links in the dialog. This can make the dialog appear in the style of modern Windows apps. If you don't like this behavior, you can set `noLink` to `true`.
+	**/
+	@:optional
+	var noLink : Bool; /**
+		Normalize the keyboard access keys across platforms. Default is `false`. Enabling this assumes `&` is used in the button labels for the placement of the keyboard shortcut access key and labels will be converted so they work correctly on each platform, `&` characters are removed on macOS, converted to `_` on Linux, and left untouched on Windows. For example, a button label of `Vie&w` will be converted to `Vie_w` on Linux and `View` on macOS and can be selected via `Alt-W` on Windows and Linux.
+	**/
+	@:optional
+	var normalizeAccessKeys : Bool; }):Int;
+	/**
+		resolves with a promise containing the following properties:
+		
+		* `response` Number - The index of the clicked button.
+		* `checkboxChecked` Boolean - The checked state of the checkbox if `checkboxLabel` was set. Otherwise `false`.
+		
+		Shows a message box, it will block the process until the message box is closed.
+		
+		The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+	**/
+	static function showMessageBox(?browserWindow:electron.main.BrowserWindow, options:{ /**
+		Can be `"none"`, `"info"`, `"error"`, `"question"` or `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless you set an icon using the `"icon"` option. On macOS, both `"warning"` and `"error"` display the same warning icon.
+	**/
+	@:optional
+	var type : String; /**
+		Array of texts for buttons. On Windows, an empty array will result in one button labeled "OK".
+	**/
+	@:optional
+	var buttons : Array<String>; /**
+		Index of the button in the buttons array which will be selected by default when the message box opens.
+	**/
+	@:optional
+	var defaultId : Int; /**
+		Title of the message box, some platforms will not show it.
+	**/
+	@:optional
+	var title : String; /**
+		Content of the message box.
+	**/
+	var message : String; /**
+		Extra information of the message.
+	**/
+	@:optional
+	var detail : String; /**
+		If provided, the message box will include a checkbox with the given label.
+	**/
+	@:optional
+	var checkboxLabel : String; /**
+		Initial checked state of the checkbox. `false` by default.
+	**/
+	@:optional
+	var checkboxChecked : Bool; @:optional
+	var icon : electron.NativeImage; /**
+		The index of the button to be used to cancel the dialog, via the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the label. If no such labeled buttons exist and this option is not set, `0` will be used as the return value.
+	**/
+	@:optional
+	var cancelId : Int; /**
+		On Windows Electron will try to figure out which one of the `buttons` are common buttons (like "Cancel" or "Yes"), and show the others as command links in the dialog. This can make the dialog appear in the style of modern Windows apps. If you don't like this behavior, you can set `noLink` to `true`.
+	**/
+	@:optional
+	var noLink : Bool; /**
+		Normalize the keyboard access keys across platforms. Default is `false`. Enabling this assumes `&` is used in the button labels for the placement of the keyboard shortcut access key and labels will be converted so they work correctly on each platform, `&` characters are removed on macOS, converted to `_` on Linux, and left untouched on Windows. For example, a button label of `Vie&w` will be converted to `Vie_w` on Linux and `View` on macOS and can be selected via `Alt-W` on Windows and Linux.
+	**/
+	@:optional
+	var normalizeAccessKeys : Bool; }):js.lib.Promise<Any>;
+	/**
+		Displays a modal dialog that shows an error message.
+		
+		This API can be called safely before the `ready` event the `app` module emits, it is usually used to report errors in early stage of startup. If called before the app `ready`event on Linux, the message will be emitted to stderr, and no GUI dialog will appear.
+	**/
+	static function showErrorBox(title:String, content:String):Void;
+	/**
+		resolves when the certificate trust dialog is shown.
+		
+		On macOS, this displays a modal dialog that shows a message and certificate information, and gives the user the option of trusting/importing the certificate. If you provide a `browserWindow` argument the dialog will be attached to the parent window, making it modal.
+		
+		On Windows the options are more limited, due to the Win32 APIs used:
+		
+		* The `message` argument is not used, as the OS provides its own confirmation dialog.
+		* The `browserWindow` argument is ignored since it is not possible to make this confirmation dialog modal.
+	**/
+	static function showCertificateTrustDialog(?browserWindow:electron.main.BrowserWindow, options:{ /**
+		The certificate to trust/import.
+	**/
+	var certificate : electron.Certificate; /**
+		The message to display to the user.
+	**/
+	var message : String; }):js.lib.Promise<Any>;
+}
+@:enum abstract DialogEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Dock.hx
+++ b/src/electron/remote/Dock.hx
@@ -1,0 +1,59 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/dock
+**/
+@:jsRequire("electron", "remote.Dock") extern class Dock extends js.node.events.EventEmitter<electron.main.Dock> {
+	/**
+		an ID representing the request.
+		
+		When `critical` is passed, the dock icon will bounce until either the application becomes active or the request is canceled.
+		
+		When `informational` is passed, the dock icon will bounce for one second. However, the request remains active until either the application becomes active or the request is canceled.
+		
+		**Nota Bene:** This method can only be used while the app is not focused; when the app is focused it will return -1.
+	**/
+	function bounce(?type:String):Int;
+	/**
+		Cancel the bounce of `id`.
+	**/
+	function cancelBounce(id:Int):Void;
+	/**
+		Bounces the Downloads stack if the filePath is inside the Downloads folder.
+	**/
+	function downloadFinished(filePath:String):Void;
+	/**
+		Sets the string to be displayed in the dock’s badging area.
+	**/
+	function setBadge(text:String):Void;
+	/**
+		The badge string of the dock.
+	**/
+	function getBadge():String;
+	/**
+		Hides the dock icon.
+	**/
+	function hide():Void;
+	/**
+		Resolves when the dock icon is shown.
+	**/
+	function show():js.lib.Promise<Any>;
+	/**
+		Whether the dock icon is visible.
+	**/
+	function isVisible():Bool;
+	/**
+		Sets the application's [dock menu][dock-menu].
+	**/
+	function setMenu(menu:electron.main.Menu):Void;
+	/**
+		The application's [dock menu][dock-menu].
+	**/
+	function getMenu():haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		Sets the `image` associated with this dock icon.
+	**/
+	function setIcon(image:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+}
+@:enum abstract DockEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/DownloadItem.hx
+++ b/src/electron/remote/DownloadItem.hx
@@ -1,0 +1,125 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/download-item
+**/
+@:jsRequire("electron", "remote.DownloadItem") extern class DownloadItem extends js.node.events.EventEmitter<electron.main.DownloadItem> {
+	/**
+		A `String` property that determines the save file path of the download item.
+		
+		The property is only available in session's `will-download` callback function. If user doesn't set the save path via the property, Electron will use the original routine to determine the save path; this usually prompts a save dialog.
+	**/
+	var savePath : String;
+	/**
+		The API is only available in session's `will-download` callback function. If user doesn't set the save path via the API, Electron will use the original routine to determine the save path; this usually prompts a save dialog.
+	**/
+	function setSavePath(path:String):Void;
+	/**
+		The save path of the download item. This will be either the path set via `downloadItem.setSavePath(path)` or the path selected from the shown save dialog.
+	**/
+	function getSavePath():String;
+	/**
+		This API allows the user to set custom options for the save dialog that opens for the download item by default. The API is only available in session's `will-download` callback function.
+	**/
+	function setSaveDialogOptions(options:SaveDialogOptions):Void;
+	/**
+		Returns the object previously set by `downloadItem.setSaveDialogOptions(options)`.
+	**/
+	function getSaveDialogOptions():SaveDialogOptions;
+	/**
+		Pauses the download.
+	**/
+	function pause():Void;
+	/**
+		Whether the download is paused.
+	**/
+	function isPaused():Bool;
+	/**
+		Resumes the download that has been paused.
+		
+		**Note:** To enable resumable downloads the server you are downloading from must support range requests and provide both `Last-Modified` and `ETag` header values. Otherwise `resume()` will dismiss previously received bytes and restart the download from the beginning.
+	**/
+	function resume():Void;
+	/**
+		Whether the download can resume.
+	**/
+	function canResume():Bool;
+	/**
+		Cancels the download operation.
+	**/
+	function cancel():Void;
+	/**
+		The origin URL where the item is downloaded from.
+	**/
+	function getURL():String;
+	/**
+		The files mime type.
+	**/
+	function getMimeType():String;
+	/**
+		Whether the download has user gesture.
+	**/
+	function hasUserGesture():Bool;
+	/**
+		The file name of the download item.
+		
+		**Note:** The file name is not always the same as the actual one saved in local disk. If user changes the file name in a prompted download saving dialog, the actual name of saved file will be different.
+	**/
+	function getFilename():String;
+	/**
+		The total size in bytes of the download item.
+		
+		If the size is unknown, it returns 0.
+	**/
+	function getTotalBytes():Int;
+	/**
+		The received bytes of the download item.
+	**/
+	function getReceivedBytes():Int;
+	/**
+		The Content-Disposition field from the response header.
+	**/
+	function getContentDisposition():String;
+	/**
+		The current state. Can be `progressing`, `completed`, `cancelled` or `interrupted`.
+		
+		**Note:** The following methods are useful specifically to resume a `cancelled` item when session is restarted.
+	**/
+	function getState():String;
+	/**
+		The complete URL chain of the item including any redirects.
+	**/
+	function getURLChain():Array<String>;
+	/**
+		Last-Modified header value.
+	**/
+	function getLastModifiedTime():String;
+	/**
+		ETag header value.
+	**/
+	function getETag():String;
+	/**
+		Number of seconds since the UNIX epoch when the download was started.
+	**/
+	function getStartTime():Float;
+}
+@:enum abstract DownloadItemEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the download has been updated and is not done.
+		
+		The `state` can be one of following:
+		
+		* `progressing` - The download is in-progress.
+		* `interrupted` - The download has interrupted and can be resumed.
+	**/
+	var updated : electron.main.DownloadItemEvent<Void -> Void> = "updated";
+	/**
+		Emitted when the download is in a terminal state. This includes a completed download, a cancelled download (via `downloadItem.cancel()`), and interrupted download that can't be resumed.
+		
+		The `state` can be one of following:
+		
+		* `completed` - The download completed successfully.
+		* `cancelled` - The download has been cancelled.
+		* `interrupted` - The download has interrupted and can not resume.
+	**/
+	var done : electron.main.DownloadItemEvent<Void -> Void> = "done";
+}

--- a/src/electron/remote/GlobalShortcut.hx
+++ b/src/electron/remote/GlobalShortcut.hx
@@ -1,0 +1,58 @@
+package electron.remote;
+/**
+	> Detect keyboard events when the application does not have keyboard focus.
+	
+	Process: Main
+	
+	The `globalShortcut` module can register/unregister a global keyboard shortcut with the operating system so that you can customize the operations for various shortcuts.
+	
+	**Note:** The shortcut is global; it will work even if the app does not have the keyboard focus. This module cannot be used before the `ready` event of the app module is emitted.
+	@see https://electronjs.org/docs/api/global-shortcut
+**/
+@:jsRequire("electron", "remote.globalShortcut") extern class GlobalShortcut extends js.node.events.EventEmitter<electron.main.GlobalShortcut> {
+	/**
+		Whether or not the shortcut was registered successfully.
+		
+		Registers a global shortcut of `accelerator`. The `callback` is called when the registered shortcut is pressed by the user.
+		
+		When the accelerator is already taken by other applications, this call will silently fail. This behavior is intended by operating systems, since they don't want applications to fight for global shortcuts.
+		
+		The following accelerators will not be registered successfully on macOS 10.14 Mojave unless the app has been authorized as a trusted accessibility client:
+		
+		* "Media Play/Pause"
+		* "Media Next Track"
+		* "Media Previous Track"
+		* "Media Stop"
+	**/
+	static function register(accelerator:electron.Accelerator, callback:haxe.Constraints.Function):Bool;
+	/**
+		Registers a global shortcut of all `accelerator` items in `accelerators`. The `callback` is called when any of the registered shortcuts are pressed by the user.
+		
+		When a given accelerator is already taken by other applications, this call will silently fail. This behavior is intended by operating systems, since they don't want applications to fight for global shortcuts.
+		
+		The following accelerators will not be registered successfully on macOS 10.14 Mojave unless the app has been authorized as a trusted accessibility client:
+		
+		* "Media Play/Pause"
+		* "Media Next Track"
+		* "Media Previous Track"
+		* "Media Stop"
+	**/
+	static function registerAll(accelerators:Array<String>, callback:haxe.Constraints.Function):Void;
+	/**
+		Whether this application has registered `accelerator`.
+		
+		When the accelerator is already taken by other applications, this call will still return `false`. This behavior is intended by operating systems, since they don't want applications to fight for global shortcuts.
+	**/
+	static function isRegistered(accelerator:electron.Accelerator):Bool;
+	/**
+		Unregisters the global shortcut of `accelerator`.
+	**/
+	static function unregister(accelerator:electron.Accelerator):Void;
+	/**
+		Unregisters all of the global shortcuts.
+	**/
+	static function unregisterAll():Void;
+}
+@:enum abstract GlobalShortcutEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/InAppPurchase.hx
+++ b/src/electron/remote/InAppPurchase.hx
@@ -1,0 +1,47 @@
+package electron.remote;
+/**
+	> In-app purchases on Mac App Store.
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/in-app-purchase
+**/
+@:jsRequire("electron", "remote.inAppPurchase") extern class InAppPurchase extends js.node.events.EventEmitter<electron.main.InAppPurchase> {
+	/**
+		Returns `true` if the product is valid and added to the payment queue.
+		
+		You should listen for the `transactions-updated` event as soon as possible and certainly before you call `purchaseProduct`.
+	**/
+	static function purchaseProduct(productID:String, ?quantity:Int):js.lib.Promise<Any>;
+	/**
+		Resolves with an array of `Product` objects.
+		
+		Retrieves the product descriptions.
+	**/
+	static function getProducts(productIDs:Array<String>):js.lib.Promise<Any>;
+	/**
+		whether a user can make a payment.
+	**/
+	static function canMakePayments():Bool;
+	/**
+		Restores finished transactions. This method can be called either to install purchases on additional devices, or to restore purchases for an application that the user deleted and reinstalled.
+		
+		The payment queue delivers a new transaction for each previously completed transaction that can be restored. Each transaction includes a copy of the original transaction.
+	**/
+	static function restoreCompletedTransactions():Void;
+	/**
+		the path to the receipt.
+	**/
+	static function getReceiptURL():String;
+	/**
+		Completes all pending transactions.
+	**/
+	static function finishAllTransactions():Void;
+	/**
+		Completes the pending transactions corresponding to the date.
+	**/
+	static function finishTransactionByDate(date:String):Void;
+	static function on<T:(haxe.Constraints.Function)>(eventType:Dynamic, callback:T):Void;
+}
+@:enum abstract InAppPurchaseEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	var transactions_updated : electron.main.InAppPurchaseEvent<Void -> Void> = "transactions-updated";
+}

--- a/src/electron/remote/IncomingMessage.hx
+++ b/src/electron/remote/IncomingMessage.hx
@@ -1,0 +1,58 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/incoming-message
+**/
+@:jsRequire("electron", "remote.IncomingMessage") extern class IncomingMessage extends js.node.events.EventEmitter<electron.main.IncomingMessage> {
+	/**
+		An `Integer` indicating the HTTP response status code.
+	**/
+	var statusCode : Int;
+	/**
+		A `String` representing the HTTP status message.
+	**/
+	var statusMessage : String;
+	/**
+		A `Record<string, string | string[]>` representing the HTTP response headers. The `headers` object is formatted as follows:
+		
+		* All header names are lowercased.
+		* Duplicates of `age`, `authorization`, `content-length`, `content-type`, `etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`, `last-modified`, `location`, `max-forwards`, `proxy-authorization`, `referer`, `retry-after`, `server`, or `user-agent` are discarded.
+		* `set-cookie` is always an array. Duplicates are added to the array.
+		* For duplicate `cookie` headers, the values are joined together with '; '.
+		* For all other headers, the values are joined together with ', '.
+	**/
+	var headers : Record;
+	/**
+		A `String` indicating the HTTP protocol version number. Typical values are '1.0' or '1.1'. Additionally `httpVersionMajor` and `httpVersionMinor` are two Integer-valued readable properties that return respectively the HTTP major and minor version numbers.
+	**/
+	var httpVersion : String;
+	/**
+		An `Integer` indicating the HTTP protocol major version number.
+	**/
+	var httpVersionMajor : Int;
+	/**
+		An `Integer` indicating the HTTP protocol minor version number.
+	**/
+	var httpVersionMinor : Int;
+}
+@:enum abstract IncomingMessageEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		The `data` event is the usual method of transferring response data into applicative code.
+	**/
+	var data : electron.main.IncomingMessageEvent<Void -> Void> = "data";
+	/**
+		Indicates that response body has ended.
+	**/
+	var end : electron.main.IncomingMessageEvent<Void -> Void> = "end";
+	/**
+		Emitted when a request has been canceled during an ongoing HTTP transaction.
+	**/
+	var aborted : electron.main.IncomingMessageEvent<Void -> Void> = "aborted";
+	/**
+		Returns:
+		
+		`error` Error - Typically holds an error string identifying failure root cause.
+		
+		Emitted when an error was encountered while streaming response data events. For instance, if the server closes the underlying while the response is still streaming, an `error` event will be emitted on the response object and a `close` event will subsequently follow on the request object.
+	**/
+	var error : electron.main.IncomingMessageEvent<Void -> Void> = "error";
+}

--- a/src/electron/remote/IpcMain.hx
+++ b/src/electron/remote/IpcMain.hx
@@ -1,0 +1,81 @@
+package electron.remote;
+/**
+	> Communicate asynchronously from the main process to renderer processes.
+	
+	Process: Main
+	
+	The `ipcMain` module is an Event Emitter. When used in the main process, it handles asynchronous and synchronous messages sent from a renderer process (web page). Messages sent from a renderer will be emitted to this module.
+	
+	### Sending Messages
+	
+	It is also possible to send messages from the main process to the renderer process, see webContents.send for more information.
+	
+	* When sending a message, the event name is the `channel`.
+	* To reply to a synchronous message, you need to set `event.returnValue`.
+	* To send an asynchronous message back to the sender, you can use `event.reply(...)`.  This helper method will automatically handle messages coming from frames that aren't the main frame (e.g. iframes) whereas `event.sender.send(...)` will always send to the main frame.
+	
+	An example of sending and handling messages between the render and main processes:
+	
+	```
+	// In main process.
+	const { ipcMain } = require('electron')
+	ipcMain.on('asynchronous-message', (event, arg) => {
+	  console.log(arg) // prints "ping"
+	  event.reply('asynchronous-reply', 'pong')
+	})
+	
+	ipcMain.on('synchronous-message', (event, arg) => {
+	  console.log(arg) // prints "ping"
+	  event.returnValue = 'pong'
+	})
+	```
+	
+	```
+	// In renderer process (web page).
+	const { ipcRenderer } = require('electron')
+	console.log(ipcRenderer.sendSync('synchronous-message', 'ping')) // prints "pong"
+	
+	ipcRenderer.on('asynchronous-reply', (event, arg) => {
+	  console.log(arg) // prints "pong"
+	})
+	ipcRenderer.send('asynchronous-message', 'ping')
+	```
+	@see https://electronjs.org/docs/api/ipc-main
+**/
+@:jsRequire("electron", "remote.ipcMain") extern class IpcMain extends js.node.events.EventEmitter<electron.main.IpcMain> {
+	/**
+		Listens to `channel`, when a new message arrives `listener` would be called with `listener(event, args...)`.
+	**/
+	static function on(channel:String, listener:haxe.Constraints.Function):Void;
+	/**
+		Adds a one time `listener` function for the event. This `listener` is invoked only the next time a message is sent to `channel`, after which it is removed.
+	**/
+	static function once(channel:String, listener:haxe.Constraints.Function):Void;
+	/**
+		Removes the specified `listener` from the listener array for the specified `channel`.
+	**/
+	static function removeListener(channel:String, listener:haxe.Constraints.Function):Void;
+	/**
+		Removes listeners of the specified `channel`.
+	**/
+	static function removeAllListeners(?channel:String):Void;
+	/**
+		Adds a handler for an `invoke`able IPC. This handler will be called whenever a renderer calls `ipcRenderer.invoke(channel, ...args)`.
+		
+		If `listener` returns a Promise, the eventual result of the promise will be returned as a reply to the remote caller. Otherwise, the return value of the listener will be used as the value of the reply.
+		
+		The `event` that is passed as the first argument to the handler is the same as that passed to a regular event listener. It includes information about which WebContents is the source of the invoke request.
+	**/
+	static function handle(channel:String, listener:haxe.Constraints.Function):Void;
+	/**
+		Handles a single `invoke`able IPC message, then removes the listener. See `ipcMain.handle(channel, listener)`.
+	**/
+	static function handleOnce(channel:String, listener:haxe.Constraints.Function):Void;
+	/**
+		Removes any handler for `channel`, if present.
+	**/
+	static function removeHandler(channel:String):Void;
+}
+@:enum abstract IpcMainEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Menu.hx
+++ b/src/electron/remote/Menu.hx
@@ -1,0 +1,94 @@
+package electron.remote;
+/**
+	> Create native application menus and context menus.
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/menu
+**/
+@:jsRequire("electron", "remote.Menu") extern class Menu extends js.node.events.EventEmitter<electron.main.Menu> {
+	/**
+		Sets `menu` as the application menu on macOS. On Windows and Linux, the `menu` will be set as each window's top menu.
+		
+		Also on Windows and Linux, you can use a `&` in the top-level item name to indicate which letter should get a generated accelerator. For example, using `&File` for the file menu would result in a generated `Alt-F` accelerator that opens the associated menu. The indicated character in the button label gets an underline. The `&` character is not displayed on the button label.
+		
+		Passing `null` will suppress the default menu. On Windows and Linux, this has the additional effect of removing the menu bar from the window.
+		
+		**Note:** The default menu will be created automatically if the app does not set one. It contains standard items such as `File`, `Edit`, `View`, `Window` and `Help`.
+	**/
+	static function setApplicationMenu(menu:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The application menu, if set, or `null`, if not set.
+		
+		**Note:** The returned `Menu` instance doesn't support dynamic addition or removal of menu items. Instance properties can still be dynamically modified.
+	**/
+	static function getApplicationMenu():haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		Sends the `action` to the first responder of application. This is used for emulating default macOS menu behaviors. Usually you would use the `role` property of a `MenuItem`.
+		
+		See the macOS Cocoa Event Handling Guide for more information on macOS' native actions.
+	**/
+	static function sendActionToFirstResponder(action:String):Void;
+	/**
+		Generally, the `template` is an array of `options` for constructing a MenuItem. The usage can be referenced above.
+		
+		You can also attach other fields to the element of the `template` and they will become properties of the constructed menu items.
+	**/
+	static function buildFromTemplate(template:Array<haxe.extern.EitherType<Dynamic, Dynamic>>):electron.main.Menu;
+	/**
+		A `MenuItem[]` array containing the menu's items.
+		
+		Each `Menu` consists of multiple `MenuItem`s and each `MenuItem` can have a submenu.
+	**/
+	var items : Array<electron.main.MenuItem>;
+	function new():Void;
+	/**
+		Pops up this menu as a context menu in the `BrowserWindow`.
+	**/
+	function popup(?options:{ /**
+		Default is the focused window.
+	**/
+	@:optional
+	var window : electron.main.BrowserWindow; /**
+		Default is the current mouse cursor position. Must be declared if `y` is declared.
+	**/
+	@:optional
+	var x : Float; /**
+		Default is the current mouse cursor position. Must be declared if `x` is declared.
+	**/
+	@:optional
+	var y : Float; /**
+		The index of the menu item to be positioned under the mouse cursor at the specified coordinates. Default is -1.
+	**/
+	@:optional
+	var positioningItem : Float; /**
+		Called when menu is closed.
+	**/
+	@:optional
+	var callback : haxe.Constraints.Function; }):Void;
+	/**
+		Closes the context menu in the `browserWindow`.
+	**/
+	function closePopup(?browserWindow:electron.main.BrowserWindow):Void;
+	/**
+		Appends the `menuItem` to the menu.
+	**/
+	function append(menuItem:electron.main.MenuItem):Void;
+	/**
+		the item with the specified `id`
+	**/
+	function getMenuItemById(id:String):haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		Inserts the `menuItem` to the `pos` position of the menu.
+	**/
+	function insert(pos:Int, menuItem:electron.main.MenuItem):Void;
+}
+@:enum abstract MenuEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when `menu.popup()` is called.
+	**/
+	var menu_will_show : electron.main.MenuEvent<Void -> Void> = "menu-will-show";
+	/**
+		Emitted when a popup is closed either manually or with `menu.closePopup()`.
+	**/
+	var menu_will_close : electron.main.MenuEvent<Void -> Void> = "menu-will-close";
+}

--- a/src/electron/remote/MenuItem.hx
+++ b/src/electron/remote/MenuItem.hx
@@ -1,0 +1,155 @@
+package electron.remote;
+/**
+	> Add items to native application menus and context menus.
+	
+	Process: Main
+	
+	See `Menu` for examples.
+	@see https://electronjs.org/docs/api/menu-item
+**/
+@:jsRequire("electron", "remote.MenuItem") extern class MenuItem extends js.node.events.EventEmitter<electron.main.MenuItem> {
+	/**
+		A `String` indicating the item's unique id, this property can be dynamically changed.
+	**/
+	var id : String;
+	/**
+		A `String` indicating the item's visible label.
+	**/
+	var label : String;
+	/**
+		A `Function` that is fired when the MenuItem receives a click event. It can be called with `menuItem.click(event, focusedWindow, focusedWebContents)`.
+		
+		* `event` KeyboardEvent
+		* `focusedWindow` BrowserWindow
+		* `focusedWebContents` WebContents
+	**/
+	var click : haxe.Constraints.Function;
+	/**
+		A `Menu` (optional) containing the menu item's submenu, if present.
+	**/
+	var submenu : electron.main.Menu;
+	/**
+		A `String` indicating the type of the item. Can be `normal`, `separator`, `submenu`, `checkbox` or `radio`.
+	**/
+	var type : String;
+	/**
+		A `String` (optional) indicating the item's role, if set. Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu`
+	**/
+	var role : String;
+	/**
+		A `Accelerator` (optional) indicating the item's accelerator, if set.
+	**/
+	var accelerator : electron.Accelerator;
+	/**
+		A `NativeImage | String` (optional) indicating the item's icon, if set.
+	**/
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		A `String` indicating the item's sublabel.
+	**/
+	var sublabel : String;
+	/**
+		A `String` indicating the item's hover text.
+	**/
+	var toolTip : String;
+	/**
+		A `Boolean` indicating whether the item is enabled, this property can be dynamically changed.
+	**/
+	var enabled : Bool;
+	/**
+		A `Boolean` indicating whether the item is visible, this property can be dynamically changed.
+	**/
+	var visible : Bool;
+	/**
+		A `Boolean` indicating whether the item is checked, this property can be dynamically changed.
+		
+		A `checkbox` menu item will toggle the `checked` property on and off when selected.
+		
+		A `radio` menu item will turn on its `checked` property when clicked, and will turn off that property for all adjacent items in the same menu.
+		
+		You can add a `click` function for additional behavior.
+	**/
+	var checked : Bool;
+	/**
+		A `Boolean` indicating if the accelerator should be registered with the system or just displayed.
+		
+		This property can be dynamically changed.
+	**/
+	var registerAccelerator : Bool;
+	/**
+		A `Number` indicating an item's sequential unique id.
+	**/
+	var commandId : Float;
+	/**
+		A `Menu` that the item is a part of.
+	**/
+	var menu : electron.main.Menu;
+	function new(options:{ /**
+		Will be called with `click(menuItem, browserWindow, event)` when the menu item is clicked.
+	**/
+	@:optional
+	var click : haxe.Constraints.Function; /**
+		Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the `click` property will be ignored. See roles.
+	**/
+	@:optional
+	var role : String; /**
+		Can be `normal`, `separator`, `submenu`, `checkbox` or `radio`.
+	**/
+	@:optional
+	var type : String; @:optional
+	var label : String; @:optional
+	var sublabel : String; /**
+		Hover text for this menu item.
+	**/
+	@:optional
+	var toolTip : String; @:optional
+	var accelerator : electron.Accelerator; @:optional
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		If false, the menu item will be greyed out and unclickable.
+	**/
+	@:optional
+	var enabled : Bool; /**
+		default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible`.
+	**/
+	@:optional
+	var acceleratorWorksWhenHidden : Bool; /**
+		If false, the menu item will be entirely hidden.
+	**/
+	@:optional
+	var visible : Bool; /**
+		Should only be specified for `checkbox` or `radio` type menu items.
+	**/
+	@:optional
+	var checked : Bool; /**
+		If false, the accelerator won't be registered with the system, but it will still be displayed. Defaults to true.
+	**/
+	@:optional
+	var registerAccelerator : Bool; /**
+		Should be specified for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted. If the value is not a `Menu` then it will be automatically converted to one using `Menu.buildFromTemplate`.
+	**/
+	@:optional
+	var submenu : haxe.extern.EitherType<Array<Dynamic>, Dynamic>; /**
+		Unique within a single menu. If defined then it can be used as a reference to this item by the position attribute.
+	**/
+	@:optional
+	var id : String; /**
+		Inserts this item before the item with the specified label. If the referenced item doesn't exist the item will be inserted at the end of  the menu. Also implies that the menu item in question should be placed in the same “group” as the item.
+	**/
+	@:optional
+	var before : Array<String>; /**
+		Inserts this item after the item with the specified label. If the referenced item doesn't exist the item will be inserted at the end of the menu.
+	**/
+	@:optional
+	var after : Array<String>; /**
+		Provides a means for a single context menu to declare the placement of their containing group before the containing group of the item with the specified label.
+	**/
+	@:optional
+	var beforeGroupContaining : Array<String>; /**
+		Provides a means for a single context menu to declare the placement of their containing group after the containing group of the item with the specified label.
+	**/
+	@:optional
+	var afterGroupContaining : Array<String>; }):Void;
+}
+@:enum abstract MenuItemEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/MessageChannelMain.hx
+++ b/src/electron/remote/MessageChannelMain.hx
@@ -1,0 +1,17 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/message-channel-main
+**/
+@:jsRequire("electron", "remote.MessageChannelMain") extern class MessageChannelMain extends js.node.events.EventEmitter<electron.main.MessageChannelMain> {
+	/**
+		A `MessagePortMain` property.
+	**/
+	var port1 : electron.main.MessagePortMain;
+	/**
+		A `MessagePortMain` property.
+	**/
+	var port2 : electron.main.MessagePortMain;
+}
+@:enum abstract MessageChannelMainEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/MessagePortMain.hx
+++ b/src/electron/remote/MessagePortMain.hx
@@ -1,0 +1,28 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/message-port-main
+**/
+@:jsRequire("electron", "remote.MessagePortMain") extern class MessagePortMain extends js.node.events.EventEmitter<electron.main.MessagePortMain> {
+	/**
+		Sends a message from the port, and optionally, transfers ownership of objects to other browsing contexts.
+	**/
+	function postMessage(message:Any, ?transfer:Array<electron.main.MessagePortMain>):Void;
+	/**
+		Starts the sending of messages queued on the port. Messages will be queued until this method is called.
+	**/
+	function start():Void;
+	/**
+		Disconnects the port, so it is no longer active.
+	**/
+	function close():Void;
+}
+@:enum abstract MessagePortMainEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when a MessagePortMain object receives a message.
+	**/
+	var message : electron.main.MessagePortMainEvent<Void -> Void> = "message";
+	/**
+		Emitted when the remote end of a MessagePortMain object becomes disconnected.
+	**/
+	var close : electron.main.MessagePortMainEvent<Void -> Void> = "close";
+}

--- a/src/electron/remote/NativeTheme.hx
+++ b/src/electron/remote/NativeTheme.hx
@@ -1,0 +1,57 @@
+package electron.remote;
+/**
+	> Read and respond to changes in Chromium's native color theme.
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/native-theme
+**/
+@:jsRequire("electron", "remote.nativeTheme") extern class NativeTheme extends js.node.events.EventEmitter<electron.main.NativeTheme> {
+	/**
+		A `Boolean` for if the OS / Chromium currently has a dark mode enabled or is being instructed to show a dark-style UI.  If you want to modify this value you should use `themeSource` below.
+	**/
+	static var shouldUseDarkColors : Bool;
+	/**
+		A `String` property that can be `system`, `light` or `dark`.  It is used to override and supersede the value that Chromium has chosen to use internally.
+		
+		Setting this property to `system` will remove the override and everything will be reset to the OS default.  By default `themeSource` is `system`.
+		
+		Settings this property to `dark` will have the following effects:
+		
+		* `nativeTheme.shouldUseDarkColors` will be `true` when accessed
+		* Any UI Electron renders on Linux and Windows including context menus, devtools, etc. will use the dark UI.
+		* Any UI the OS renders on macOS including menus, window frames, etc. will use the dark UI.
+		* The `prefers-color-scheme` CSS query will match `dark` mode.
+		* The `updated` event will be emitted
+		
+		Settings this property to `light` will have the following effects:
+		
+		* `nativeTheme.shouldUseDarkColors` will be `false` when accessed
+		* Any UI Electron renders on Linux and Windows including context menus, devtools, etc. will use the light UI.
+		* Any UI the OS renders on macOS including menus, window frames, etc. will use the light UI.
+		* The `prefers-color-scheme` CSS query will match `light` mode.
+		* The `updated` event will be emitted
+		
+		The usage of this property should align with a classic "dark mode" state machine in your application where the user has three options.
+		
+		* `Follow OS` --> `themeSource = 'system'`
+		* `Dark Mode` --> `themeSource = 'dark'`
+		* `Light Mode` --> `themeSource = 'light'`
+		
+		Your application should then always use `shouldUseDarkColors` to determine what CSS to apply.
+	**/
+	static var themeSource : String;
+	/**
+		A `Boolean` for if the OS / Chromium currently has high-contrast mode enabled or is being instructed to show a high-contrast UI.
+	**/
+	static var shouldUseHighContrastColors : Bool;
+	/**
+		A `Boolean` for if the OS / Chromium currently has an inverted color scheme or is being instructed to use an inverted color scheme.
+	**/
+	static var shouldUseInvertedColorScheme : Bool;
+}
+@:enum abstract NativeThemeEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when something in the underlying NativeTheme has changed. This normally means that either the value of `shouldUseDarkColors`, `shouldUseHighContrastColors` or `shouldUseInvertedColorScheme` has changed. You will have to check them to determine which one has changed.
+	**/
+	var updated : electron.main.NativeThemeEvent<Void -> Void> = "updated";
+}

--- a/src/electron/remote/Net.hx
+++ b/src/electron/remote/Net.hx
@@ -1,0 +1,50 @@
+package electron.remote;
+/**
+	> Issue HTTP/HTTPS requests using Chromium's native networking library
+	
+	Process: Main
+	
+	The `net` module is a client-side API for issuing HTTP(S) requests. It is similar to the HTTP and HTTPS modules of Node.js but uses Chromium's native networking library instead of the Node.js implementation, offering better support for web proxies.
+	
+	The following is a non-exhaustive list of why you may consider using the `net` module instead of the native Node.js modules:
+	
+	* Automatic management of system proxy configuration, support of the wpad protocol and proxy pac configuration files.
+	* Automatic tunneling of HTTPS requests.
+	* Support for authenticating proxies using basic, digest, NTLM, Kerberos or negotiate authentication schemes.
+	* Support for traffic monitoring proxies: Fiddler-like proxies used for access control and monitoring.
+	
+	The API components (including classes, methods, properties and event names) are similar to those used in Node.js.
+	
+	Example usage:
+	
+	```
+	const { app } = require('electron')
+	app.whenReady().then(() => {
+	  const { net } = require('electron')
+	  const request = net.request('https://github.com')
+	  request.on('response', (response) => {
+	    console.log(`STATUS: ${response.statusCode}`)
+	    console.log(`HEADERS: ${JSON.stringify(response.headers)}`)
+	    response.on('data', (chunk) => {
+	      console.log(`BODY: ${chunk}`)
+	    })
+	    response.on('end', () => {
+	      console.log('No more data in response.')
+	    })
+	  })
+	  request.end()
+	})
+	```
+	
+	The `net` API can be used only after the application emits the `ready` event. Trying to use the module before the `ready` event will throw an error.
+	@see https://electronjs.org/docs/api/net
+**/
+@:jsRequire("electron", "remote.net") extern class Net extends js.node.events.EventEmitter<electron.main.Net> {
+	/**
+		Creates a `ClientRequest` instance using the provided `options` which are directly forwarded to the `ClientRequest` constructor. The `net.request` method would be used to issue both secure and insecure HTTP requests according to the specified protocol scheme in the `options` object.
+	**/
+	static function request(options:haxe.extern.EitherType<Dynamic, Dynamic>):electron.main.ClientRequest;
+}
+@:enum abstract NetEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/NetLog.hx
+++ b/src/electron/remote/NetLog.hx
@@ -1,0 +1,51 @@
+package electron.remote;
+/**
+	> Logging network events for a session.
+	
+	Process: Main
+	
+	```
+	const { netLog } = require('electron')
+	
+	app.whenReady().then(async () => {
+	  await netLog.startLogging('/path/to/net-log')
+	  // After some network events
+	  const path = await netLog.stopLogging()
+	  console.log('Net-logs written to', path)
+	})
+	```
+	
+	See `--log-net-log` to log network events throughout the app's lifecycle.
+	
+	**Note:** All methods unless specified can only be used after the `ready` event of the `app` module gets emitted.
+	@see https://electronjs.org/docs/api/net-log
+**/
+@:jsRequire("electron", "remote.netLog") extern class NetLog extends js.node.events.EventEmitter<electron.main.NetLog> {
+	/**
+		A `Boolean` property that indicates whether network logs are currently being recorded.
+	**/
+	static var currentlyLogging : Bool;
+	/**
+		resolves when the net log has begun recording.
+		
+		Starts recording network events to `path`.
+	**/
+	static function startLogging(path:String, ?options:{ /**
+		What kinds of data should be captured. By default, only metadata about requests will be captured. Setting this to `includeSensitive` will include cookies and authentication data. Setting it to `everything` will include all bytes transferred on sockets. Can be `default`, `includeSensitive` or `everything`.
+	**/
+	@:optional
+	var captureMode : String; /**
+		When the log grows beyond this size, logging will automatically stop. Defaults to unlimited.
+	**/
+	@:optional
+	var maxFileSize : Float; }):js.lib.Promise<Any>;
+	/**
+		resolves when the net log has been flushed to disk.
+		
+		Stops recording network events. If not called, net logging will automatically end when app quits.
+	**/
+	static function stopLogging():js.lib.Promise<Any>;
+}
+@:enum abstract NetLogEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Notification.hx
+++ b/src/electron/remote/Notification.hx
@@ -1,0 +1,161 @@
+package electron.remote;
+/**
+	> Create OS desktop notifications
+	
+	Process: Main
+	
+	### Using in the renderer process
+	
+	If you want to show Notifications from a renderer process you should use the HTML5 Notification API
+	
+	### Class: Notification
+	
+	> Create OS desktop notifications
+	
+	Process: Main
+	
+	`Notification` is an EventEmitter.
+	
+	It creates a new `Notification` with native properties as set by the `options`.
+	
+	### Static Methods
+	
+	The `Notification` class has the following static methods:
+	
+	### `Notification.isSupported()`
+	
+	Returns `Boolean` - Whether or not desktop notifications are supported on the current system
+	@see https://electronjs.org/docs/api/notification
+**/
+@:jsRequire("electron", "remote.Notification") extern class Notification extends js.node.events.EventEmitter<electron.main.Notification> {
+	/**
+		Whether or not desktop notifications are supported on the current system
+	**/
+	static function isSupported():Bool;
+	/**
+		A `String` property representing the title of the notification.
+	**/
+	var title : String;
+	/**
+		A `String` property representing the subtitle of the notification.
+	**/
+	var subtitle : String;
+	/**
+		A `String` property representing the body of the notification.
+	**/
+	var body : String;
+	/**
+		A `String` property representing the reply placeholder of the notification.
+	**/
+	var replyPlaceholder : String;
+	/**
+		A `String` property representing the sound of the notification.
+	**/
+	var sound : String;
+	/**
+		A `String` property representing the close button text of the notification.
+	**/
+	var closeButtonText : String;
+	/**
+		A `Boolean` property representing whether the notification is silent.
+	**/
+	var silent : Bool;
+	/**
+		A `Boolean` property representing whether the notification has a reply action.
+	**/
+	var hasReply : Bool;
+	/**
+		A `String` property representing the urgency level of the notification. Can be 'normal', 'critical', or 'low'.
+		
+		Default is 'low' - see NotifyUrgency for more information.
+	**/
+	var urgency : String;
+	/**
+		A `String` property representing the type of timeout duration for the notification. Can be 'default' or 'never'.
+		
+		If `timeoutType` is set to 'never', the notification never expires. It stays open until closed by the calling API or the user.
+	**/
+	var timeoutType : String;
+	/**
+		A `NotificationAction[]` property representing the actions of the notification.
+	**/
+	var actions : Array<electron.NotificationAction>;
+	function new(?options:{ /**
+		A title for the notification, which will be shown at the top of the notification window when it is shown.
+	**/
+	var title : String; /**
+		A subtitle for the notification, which will be displayed below the title.
+	**/
+	@:optional
+	var subtitle : String; /**
+		The body text of the notification, which will be displayed below the title or subtitle.
+	**/
+	var body : String; /**
+		Whether or not to emit an OS notification noise when showing the notification.
+	**/
+	@:optional
+	var silent : Bool; /**
+		An icon to use in the notification.
+	**/
+	@:optional
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		Whether or not to add an inline reply option to the notification.
+	**/
+	@:optional
+	var hasReply : Bool; /**
+		The timeout duration of the notification. Can be 'default' or 'never'.
+	**/
+	@:optional
+	var timeoutType : String; /**
+		The placeholder to write in the inline reply input field.
+	**/
+	@:optional
+	var replyPlaceholder : String; /**
+		The name of the sound file to play when the notification is shown.
+	**/
+	@:optional
+	var sound : String; /**
+		The urgency level of the notification. Can be 'normal', 'critical', or 'low'.
+	**/
+	@:optional
+	var urgency : String; /**
+		Actions to add to the notification. Please read the available actions and limitations in the `NotificationAction` documentation.
+	**/
+	@:optional
+	var actions : Array<electron.NotificationAction>; /**
+		A custom title for the close button of an alert. An empty string will cause the default localized text to be used.
+	**/
+	@:optional
+	var closeButtonText : String; }):Void;
+	/**
+		Immediately shows the notification to the user, please note this means unlike the HTML5 Notification implementation, instantiating a `new Notification` does not immediately show it to the user, you need to call this method before the OS will display it.
+		
+		If the notification has been shown before, this method will dismiss the previously shown notification and create a new one with identical properties.
+	**/
+	function show():Void;
+	/**
+		Dismisses the notification.
+	**/
+	function close():Void;
+}
+@:enum abstract NotificationEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the notification is shown to the user, note this could be fired multiple times as a notification can be shown multiple times through the `show()` method.
+	**/
+	var show : electron.main.NotificationEvent<Void -> Void> = "show";
+	/**
+		Emitted when the notification is clicked by the user.
+	**/
+	var click : electron.main.NotificationEvent<Void -> Void> = "click";
+	/**
+		Emitted when the notification is closed by manual intervention from the user.
+		
+		This event is not guaranteed to be emitted in all cases where the notification is closed.
+	**/
+	var close : electron.main.NotificationEvent<Void -> Void> = "close";
+	/**
+		Emitted when the user clicks the "Reply" button on a notification with `hasReply: true`.
+	**/
+	var reply : electron.main.NotificationEvent<Void -> Void> = "reply";
+	var action : electron.main.NotificationEvent<Void -> Void> = "action";
+}

--- a/src/electron/remote/PowerMonitor.hx
+++ b/src/electron/remote/PowerMonitor.hx
@@ -1,0 +1,51 @@
+package electron.remote;
+/**
+	> Monitor power state changes.
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/power-monitor
+**/
+@:jsRequire("electron", "remote.powerMonitor") extern class PowerMonitor extends js.node.events.EventEmitter<electron.main.PowerMonitor> {
+	/**
+		The system's current state. Can be `active`, `idle`, `locked` or `unknown`.
+		
+		Calculate the system idle state. `idleThreshold` is the amount of time (in seconds) before considered idle.  `locked` is available on supported systems only.
+	**/
+	static function getSystemIdleState(idleThreshold:Int):String;
+	/**
+		Idle time in seconds
+		
+		Calculate system idle time in seconds.
+	**/
+	static function getSystemIdleTime():Int;
+}
+@:enum abstract PowerMonitorEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the system is suspending.
+	**/
+	var suspend : electron.main.PowerMonitorEvent<Void -> Void> = "suspend";
+	/**
+		Emitted when system is resuming.
+	**/
+	var resume : electron.main.PowerMonitorEvent<Void -> Void> = "resume";
+	/**
+		Emitted when the system changes to AC power.
+	**/
+	var on_ac : electron.main.PowerMonitorEvent<Void -> Void> = "on-ac";
+	/**
+		Emitted when system changes to battery power.
+	**/
+	var on_battery : electron.main.PowerMonitorEvent<Void -> Void> = "on-battery";
+	/**
+		Emitted when the system is about to reboot or shut down. If the event handler invokes `e.preventDefault()`, Electron will attempt to delay system shutdown in order for the app to exit cleanly. If `e.preventDefault()` is called, the app should exit as soon as possible by calling something like `app.quit()`.
+	**/
+	var shutdown : electron.main.PowerMonitorEvent<Void -> Void> = "shutdown";
+	/**
+		Emitted when the system is about to lock the screen.
+	**/
+	var lock_screen : electron.main.PowerMonitorEvent<Void -> Void> = "lock-screen";
+	/**
+		Emitted as soon as the systems screen is unlocked.
+	**/
+	var unlock_screen : electron.main.PowerMonitorEvent<Void -> Void> = "unlock-screen";
+}

--- a/src/electron/remote/PowerSaveBlocker.hx
+++ b/src/electron/remote/PowerSaveBlocker.hx
@@ -1,0 +1,32 @@
+package electron.remote;
+/**
+	> Block the system from entering low-power (sleep) mode.
+	
+	Process: Main
+	
+	For example:
+	@see https://electronjs.org/docs/api/power-save-blocker
+**/
+@:jsRequire("electron", "remote.powerSaveBlocker") extern class PowerSaveBlocker extends js.node.events.EventEmitter<electron.main.PowerSaveBlocker> {
+	/**
+		The blocker ID that is assigned to this power blocker.
+		
+		Starts preventing the system from entering lower-power mode. Returns an integer identifying the power save blocker.
+		
+		**Note:** `prevent-display-sleep` has higher precedence over `prevent-app-suspension`. Only the highest precedence type takes effect. In other words, `prevent-display-sleep` always takes precedence over `prevent-app-suspension`.
+		
+		For example, an API calling A requests for `prevent-app-suspension`, and another calling B requests for `prevent-display-sleep`. `prevent-display-sleep` will be used until B stops its request. After that, `prevent-app-suspension` is used.
+	**/
+	static function start(type:String):Int;
+	/**
+		Stops the specified power save blocker.
+	**/
+	static function stop(id:Int):Void;
+	/**
+		Whether the corresponding `powerSaveBlocker` has started.
+	**/
+	static function isStarted(id:Int):Bool;
+}
+@:enum abstract PowerSaveBlockerEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Protocol.hx
+++ b/src/electron/remote/Protocol.hx
@@ -1,0 +1,169 @@
+package electron.remote;
+/**
+	> Register a custom protocol and intercept existing protocol requests.
+	
+	Process: Main
+	
+	An example of implementing a protocol that has the same effect as the `file://` protocol:
+	
+	```
+	const { app, protocol } = require('electron')
+	const path = require('path')
+	
+	app.whenReady().then(() => {
+	  protocol.registerFileProtocol('atom', (request, callback) => {
+	    const url = request.url.substr(7)
+	    callback({ path: path.normalize(`${__dirname}/${url}`) })
+	  })
+	})
+	```
+	
+	**Note:** All methods unless specified can only be used after the `ready` event of the `app` module gets emitted.
+	
+	### Using `protocol` with a custom `partition` or `session`
+	
+	A protocol is registered to a specific Electron `session` object. If you don't specify a session, then your `protocol` will be applied to the default session that Electron uses. However, if you define a `partition` or `session` on your `browserWindow`'s `webPreferences`, then that window will use a different session and your custom protocol will not work if you just use `electron.protocol.XXX`.
+	
+	To have your custom protocol work in combination with a custom session, you need to register it to that session explicitly.
+	
+	```
+	const { session, app, protocol } = require('electron')
+	const path = require('path')
+	
+	app.whenReady().then(() => {
+	  const partition = 'persist:example'
+	  const ses = session.fromPartition(partition)
+	
+	  ses.protocol.registerFileProtocol('atom', (request, callback) => {
+	    const url = request.url.substr(7)
+	    callback({ path: path.normalize(`${__dirname}/${url}`) })
+	  })
+	
+	  mainWindow = new BrowserWindow({ webPreferences: { partition } })
+	})
+	```
+	@see https://electronjs.org/docs/api/protocol
+**/
+@:jsRequire("electron", "remote.protocol") extern class Protocol extends js.node.events.EventEmitter<electron.main.Protocol> {
+	/**
+		**Note:** This method can only be used before the `ready` event of the `app` module gets emitted and can be called only once.
+		
+		Registers the `scheme` as standard, secure, bypasses content security policy for resources, allows registering ServiceWorker, supports fetch API, and streaming video/audio. Specify a privilege with the value of `true` to enable the capability.
+		
+		An example of registering a privileged scheme, that bypasses Content Security Policy:
+		
+		A standard scheme adheres to what RFC 3986 calls generic URI syntax. For example `http` and `https` are standard schemes, while `file` is not.
+		
+		Registering a scheme as standard allows relative and absolute resources to be resolved correctly when served. Otherwise the scheme will behave like the `file` protocol, but without the ability to resolve relative URLs.
+		
+		For example when you load following page with custom protocol without registering it as standard scheme, the image will not be loaded because non-standard schemes can not recognize relative URLs:
+		
+		Registering a scheme as standard will allow access to files through the FileSystem API. Otherwise the renderer will throw a security error for the scheme.
+		
+		By default web storage apis (localStorage, sessionStorage, webSQL, indexedDB, cookies) are disabled for non standard schemes. So in general if you want to register a custom protocol to replace the `http` protocol, you have to register it as a standard scheme.
+		
+		Protocols that use streams (http and stream protocols) should set `stream: true`. The `<video>` and `<audio>` HTML elements expect protocols to buffer their responses by default. The `stream` flag configures those elements to correctly expect streaming responses.
+	**/
+	static function registerSchemesAsPrivileged(customSchemes:Array<electron.CustomScheme>):Void;
+	/**
+		Whether the protocol was successfully registered
+		
+		Registers a protocol of `scheme` that will send a file as the response. The `handler` will be called with `request` and `callback` where `request` is an incoming request for the `scheme`.
+		
+		To handle the `request`, the `callback` should be called with either the file's path or an object that has a `path` property, e.g. `callback(filePath)` or `callback({ path: filePath })`. The `filePath` must be an absolute path.
+		
+		By default the `scheme` is treated like `http:`, which is parsed differently from protocols that follow the "generic URI syntax" like `file:`.
+	**/
+	static function registerFileProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully registered
+		
+		Registers a protocol of `scheme` that will send a `Buffer` as a response.
+		
+		The usage is the same with `registerFileProtocol`, except that the `callback` should be called with either a `Buffer` object or an object that has the `data` property.
+		
+		Example:
+	**/
+	static function registerBufferProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully registered
+		
+		Registers a protocol of `scheme` that will send a `String` as a response.
+		
+		The usage is the same with `registerFileProtocol`, except that the `callback` should be called with either a `String` or an object that has the `data` property.
+	**/
+	static function registerStringProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully registered
+		
+		Registers a protocol of `scheme` that will send an HTTP request as a response.
+		
+		The usage is the same with `registerFileProtocol`, except that the `callback` should be called with an object that has the `url` property.
+	**/
+	static function registerHttpProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully registered
+		
+		Registers a protocol of `scheme` that will send a stream as a response.
+		
+		The usage is the same with `registerFileProtocol`, except that the `callback` should be called with either a `ReadableStream` object or an object that has the `data` property.
+		
+		Example:
+		
+		It is possible to pass any object that implements the readable stream API (emits `data`/`end`/`error` events). For example, here's how a file could be returned:
+	**/
+	static function registerStreamProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully unregistered
+		
+		Unregisters the custom protocol of `scheme`.
+	**/
+	static function unregisterProtocol(scheme:String):Bool;
+	/**
+		Whether `scheme` is already registered.
+	**/
+	static function isProtocolRegistered(scheme:String):Bool;
+	/**
+		Whether the protocol was successfully intercepted
+		
+		Intercepts `scheme` protocol and uses `handler` as the protocol's new handler which sends a file as a response.
+	**/
+	static function interceptFileProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully intercepted
+		
+		Intercepts `scheme` protocol and uses `handler` as the protocol's new handler which sends a `String` as a response.
+	**/
+	static function interceptStringProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully intercepted
+		
+		Intercepts `scheme` protocol and uses `handler` as the protocol's new handler which sends a `Buffer` as a response.
+	**/
+	static function interceptBufferProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully intercepted
+		
+		Intercepts `scheme` protocol and uses `handler` as the protocol's new handler which sends a new HTTP request as a response.
+	**/
+	static function interceptHttpProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully intercepted
+		
+		Same as `protocol.registerStreamProtocol`, except that it replaces an existing protocol handler.
+	**/
+	static function interceptStreamProtocol(scheme:String, handler:haxe.Constraints.Function):Bool;
+	/**
+		Whether the protocol was successfully unintercepted
+		
+		Remove the interceptor installed for `scheme` and restore its original handler.
+	**/
+	static function uninterceptProtocol(scheme:String):Bool;
+	/**
+		Whether `scheme` is already intercepted.
+	**/
+	static function isProtocolIntercepted(scheme:String):Bool;
+}
+@:enum abstract ProtocolEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Screen.hx
+++ b/src/electron/remote/Screen.hx
@@ -1,0 +1,80 @@
+package electron.remote;
+/**
+	> Retrieve information about screen size, displays, cursor position, etc.
+	
+	Process: Main
+	
+	This module cannot be used until the `ready` event of the `app` module is emitted.
+	
+	`screen` is an EventEmitter.
+	
+	**Note:** In the renderer / DevTools, `window.screen` is a reserved DOM property, so writing `let { screen } = require('electron')` will not work.
+	
+	An example of creating a window that fills the whole screen:
+	
+	```
+	const { app, BrowserWindow, screen } = require('electron')
+	
+	let win
+	app.whenReady().then(() => {
+	  const { width, height } = screen.getPrimaryDisplay().workAreaSize
+	  win = new BrowserWindow({ width, height })
+	  win.loadURL('https://github.com')
+	})
+	```
+	
+	Another example of creating a window in the external display:
+	@see https://electronjs.org/docs/api/screen
+**/
+@:native('require(\"electron\").remote.screen') extern class Screen extends js.node.events.EventEmitter<electron.main.Screen> {
+	/**
+		The current absolute position of the mouse pointer.
+	**/
+	static function getCursorScreenPoint():electron.Point;
+	/**
+		The primary display.
+	**/
+	static function getPrimaryDisplay():electron.Display;
+	/**
+		An array of displays that are currently available.
+	**/
+	static function getAllDisplays():Array<electron.Display>;
+	/**
+		The display nearest the specified point.
+	**/
+	static function getDisplayNearestPoint(point:electron.Point):electron.Display;
+	/**
+		The display that most closely intersects the provided bounds.
+	**/
+	static function getDisplayMatching(rect:electron.Rectangle):electron.Display;
+	/**
+		Converts a screen physical point to a screen DIP point. The DPI scale is performed relative to the display containing the physical point.
+	**/
+	static function screenToDipPoint(point:electron.Point):electron.Point;
+	/**
+		Converts a screen DIP point to a screen physical point. The DPI scale is performed relative to the display containing the DIP point.
+	**/
+	static function dipToScreenPoint(point:electron.Point):electron.Point;
+	/**
+		Converts a screen physical rect to a screen DIP rect. The DPI scale is performed relative to the display nearest to `window`. If `window` is null, scaling will be performed to the display nearest to `rect`.
+	**/
+	static function screenToDipRect(window:haxe.extern.EitherType<Dynamic, Dynamic>, rect:electron.Rectangle):electron.Rectangle;
+	/**
+		Converts a screen DIP rect to a screen physical rect. The DPI scale is performed relative to the display nearest to `window`. If `window` is null, scaling will be performed to the display nearest to `rect`.
+	**/
+	static function dipToScreenRect(window:haxe.extern.EitherType<Dynamic, Dynamic>, rect:electron.Rectangle):electron.Rectangle;
+}
+@:enum abstract ScreenEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when `newDisplay` has been added.
+	**/
+	var display_added : electron.main.ScreenEvent<Void -> Void> = "display-added";
+	/**
+		Emitted when `oldDisplay` has been removed.
+	**/
+	var display_removed : electron.main.ScreenEvent<Void -> Void> = "display-removed";
+	/**
+		Emitted when one or more metrics change in a `display`. The `changedMetrics` is an array of strings that describe the changes. Possible changes are `bounds`, `workArea`, `scaleFactor` and `rotation`.
+	**/
+	var display_metrics_changed : electron.main.ScreenEvent<Void -> Void> = "display-metrics-changed";
+}

--- a/src/electron/remote/ServiceWorkers.hx
+++ b/src/electron/remote/ServiceWorkers.hx
@@ -1,0 +1,22 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/service-workers
+**/
+@:jsRequire("electron", "remote.ServiceWorkers") extern class ServiceWorkers extends js.node.events.EventEmitter<electron.main.ServiceWorkers> {
+	/**
+		A ServiceWorkerInfo object where the keys are the service worker version ID and the values are the information about that service worker.
+	**/
+	function getAllRunning():Record;
+	/**
+		Information about this service worker
+		
+		If the service worker does not exist or is not running this method will throw an exception.
+	**/
+	function getFromVersionID(versionId:Float):electron.ServiceWorkerInfo;
+}
+@:enum abstract ServiceWorkersEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when a service worker logs something to the console.
+	**/
+	var console_message : electron.main.ServiceWorkersEvent<Void -> Void> = "console-message";
+}

--- a/src/electron/remote/Session.hx
+++ b/src/electron/remote/Session.hx
@@ -1,0 +1,365 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/session
+**/
+@:jsRequire("electron", "remote.Session") extern class Session extends js.node.events.EventEmitter<electron.main.Session> {
+	/**
+		A `Session` object, the default session object of the app.
+	**/
+	static var defaultSession : electron.main.Session;
+	/**
+		A session instance from `partition` string. When there is an existing `Session` with the same `partition`, it will be returned; otherwise a new `Session` instance will be created with `options`.
+		
+		If `partition` starts with `persist:`, the page will use a persistent session available to all pages in the app with the same `partition`. if there is no `persist:` prefix, the page will use an in-memory session. If the `partition` is empty then default session of the app will be returned.
+		
+		To create a `Session` with `options`, you have to ensure the `Session` with the `partition` has never been used before. There is no way to change the `options` of an existing `Session` object.
+	**/
+	static function fromPartition(partition:String, ?options:{ /**
+		Whether to enable cache.
+	**/
+	var cache : Bool; }):electron.main.Session;
+	/**
+		A `String[]` array which consists of all the known available spell checker languages.  Providing a language code to the `setSpellCheckerLanaguages` API that isn't in this array will result in an error.
+	**/
+	var availableSpellCheckerLanguages : Array<String>;
+	/**
+		A `Cookies` object for this session.
+	**/
+	var cookies : electron.main.Cookies;
+	/**
+		A `ServiceWorkers` object for this session.
+	**/
+	var serviceWorkers : electron.main.ServiceWorkers;
+	/**
+		A `WebRequest` object for this session.
+	**/
+	var webRequest : electron.main.WebRequest;
+	/**
+		A `Protocol` object for this session.
+	**/
+	var protocol : electron.main.Protocol;
+	/**
+		A `NetLog` object for this session.
+	**/
+	var netLog : electron.main.NetLog;
+	/**
+		the session's current cache size, in bytes.
+	**/
+	function getCacheSize():js.lib.Promise<Any>;
+	/**
+		resolves when the cache clear operation is complete.
+		
+		Clears the session’s HTTP cache.
+	**/
+	function clearCache():js.lib.Promise<Any>;
+	/**
+		resolves when the storage data has been cleared.
+	**/
+	function clearStorageData(?options:{ /**
+		Should follow `window.location.origin`’s representation `scheme://host:port`.
+	**/
+	@:optional
+	var origin : String; /**
+		The types of storages to clear, can contain: `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`, `shadercache`, `websql`, `serviceworkers`, `cachestorage`. If not specified, clear all storage types.
+	**/
+	@:optional
+	var storages : Array<String>; /**
+		The types of quotas to clear, can contain: `temporary`, `persistent`, `syncable`. If not specified, clear all quotas.
+	**/
+	@:optional
+	var quotas : Array<String>; }):js.lib.Promise<Any>;
+	/**
+		Writes any unwritten DOMStorage data to disk.
+	**/
+	function flushStorageData():Void;
+	/**
+		Resolves when the proxy setting process is complete.
+		
+		Sets the proxy settings.
+		
+		When `pacScript` and `proxyRules` are provided together, the `proxyRules` option is ignored and `pacScript` configuration is applied.
+		
+		The `proxyRules` has to follow the rules below:
+		
+		For example:
+		
+		* `http=foopy:80;ftp=foopy2` - Use HTTP proxy `foopy:80` for `http://` URLs, and HTTP proxy `foopy2:80` for `ftp://` URLs.
+		* `foopy:80` - Use HTTP proxy `foopy:80` for all URLs.
+		* `foopy:80,bar,direct://` - Use HTTP proxy `foopy:80` for all URLs, failing over to `bar` if `foopy:80` is unavailable, and after that using no proxy.
+		* `socks4://foopy` - Use SOCKS v4 proxy `foopy:1080` for all URLs.
+		* `http=foopy,socks5://bar.com` - Use HTTP proxy `foopy` for http URLs, and fail over to the SOCKS5 proxy `bar.com` if `foopy` is unavailable.
+		* `http=foopy,direct://` - Use HTTP proxy `foopy` for http URLs, and use no proxy if `foopy` is unavailable.
+		* `http=foopy;socks=foopy2` - Use HTTP proxy `foopy` for http URLs, and use `socks4://foopy2` for all other URLs.
+		
+		The `proxyBypassRules` is a comma separated list of rules described below:
+		
+		* `[ URL_SCHEME "://" ] HOSTNAME_PATTERN [ ":" <port> ]`
+		
+		Match all hostnames that match the pattern HOSTNAME_PATTERN.
+		
+		Examples: "foobar.com", "*foobar.com", "*.foobar.com", "*foobar.com:99", "https://x.*.y.com:99"
+		* `"." HOSTNAME_SUFFIX_PATTERN [ ":" PORT ]`
+		
+		Match a particular domain suffix.
+		
+		Examples: ".google.com", ".com", "http://.google.com"
+		* `[ SCHEME "://" ] IP_LITERAL [ ":" PORT ]`
+		
+		Match URLs which are IP address literals.
+		
+		Examples: "127.0.1", "[0:0::1]", "[::1]", "http://[::1]:99"
+		* `IP_LITERAL "/" PREFIX_LENGTH_IN_BITS`
+		
+		Match any URL that is to an IP literal that falls between the given range. IP range is specified using CIDR notation.
+		
+		Examples: "192.168.1.1/16", "fefe:13::abc/33".
+		* `<local>`
+		
+		Match local addresses. The meaning of `<local>` is whether the host matches one of: "127.0.0.1", "::1", "localhost".
+	**/
+	function setProxy(config:{ /**
+		The URL associated with the PAC file.
+	**/
+	@:optional
+	var pacScript : String; /**
+		Rules indicating which proxies to use.
+	**/
+	@:optional
+	var proxyRules : String; /**
+		Rules indicating which URLs should bypass the proxy settings.
+	**/
+	@:optional
+	var proxyBypassRules : String; }):js.lib.Promise<Any>;
+	/**
+		Resolves with the proxy information for `url`.
+	**/
+	function resolveProxy(url:String):js.lib.Promise<Any>;
+	/**
+		Sets download saving directory. By default, the download directory will be the `Downloads` under the respective app folder.
+	**/
+	function setDownloadPath(path:String):Void;
+	/**
+		Emulates network with the given configuration for the `session`.
+	**/
+	function enableNetworkEmulation(options:{ /**
+		Whether to emulate network outage. Defaults to false.
+	**/
+	@:optional
+	var offline : Bool; /**
+		RTT in ms. Defaults to 0 which will disable latency throttling.
+	**/
+	@:optional
+	var latency : Float; /**
+		Download rate in Bps. Defaults to 0 which will disable download throttling.
+	**/
+	@:optional
+	var downloadThroughput : Float; /**
+		Upload rate in Bps. Defaults to 0 which will disable upload throttling.
+	**/
+	@:optional
+	var uploadThroughput : Float; }):Void;
+	/**
+		Preconnects the given number of sockets to an origin.
+	**/
+	function preconnect(options:{ /**
+		URL for preconnect. Only the origin is relevant for opening the socket.
+	**/
+	var url : String; /**
+		number of sockets to preconnect. Must be between 1 and 6. Defaults to 1.
+	**/
+	@:optional
+	var numSockets : Float; }):Void;
+	/**
+		Disables any network emulation already active for the `session`. Resets to the original network configuration.
+	**/
+	function disableNetworkEmulation():Void;
+	/**
+		Sets the certificate verify proc for `session`, the `proc` will be called with `proc(request, callback)` whenever a server certificate verification is requested. Calling `callback(0)` accepts the certificate, calling `callback(-2)` rejects it.
+		
+		Calling `setCertificateVerifyProc(null)` will revert back to default certificate verify proc.
+	**/
+	function setCertificateVerifyProc(proc:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Sets the handler which can be used to respond to permission requests for the `session`. Calling `callback(true)` will allow the permission and `callback(false)` will reject it. To clear the handler, call `setPermissionRequestHandler(null)`.
+	**/
+	function setPermissionRequestHandler(handler:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Sets the handler which can be used to respond to permission checks for the `session`. Returning `true` will allow the permission and `false` will reject it. To clear the handler, call `setPermissionCheckHandler(null)`.
+	**/
+	function setPermissionCheckHandler(handler:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Resolves when the operation is complete.
+		
+		Clears the host resolver cache.
+	**/
+	function clearHostResolverCache():js.lib.Promise<Any>;
+	/**
+		Dynamically sets whether to always send credentials for HTTP NTLM or Negotiate authentication.
+	**/
+	function allowNTLMCredentialsForDomains(domains:String):Void;
+	/**
+		Overrides the `userAgent` and `acceptLanguages` for this session.
+		
+		The `acceptLanguages` must a comma separated ordered list of language codes, for example `"en-US,fr,de,ko,zh-CN,ja"`.
+		
+		This doesn't affect existing `WebContents`, and each `WebContents` can use `webContents.setUserAgent` to override the session-wide user agent.
+	**/
+	function setUserAgent(userAgent:String, ?acceptLanguages:String):Void;
+	/**
+		Whether or not this session is a persistent one. The default `webContents` session of a `BrowserWindow` is persistent. When creating a session from a partition, session prefixed with `persist:` will be persistent, while others will be temporary.
+	**/
+	function isPersistent():Bool;
+	/**
+		The user agent for this session.
+	**/
+	function getUserAgent():String;
+	/**
+		resolves with blob data.
+	**/
+	function getBlobData(identifier:String):js.lib.Promise<Any>;
+	/**
+		Initiates a download of the resource at `url`. The API will generate a DownloadItem that can be accessed with the will-download event.
+		
+		**Note:** This does not perform any security checks that relate to a page's origin, unlike `webContents.downloadURL`.
+	**/
+	function downloadURL(url:String):Void;
+	/**
+		Allows resuming `cancelled` or `interrupted` downloads from previous `Session`. The API will generate a DownloadItem that can be accessed with the will-download event. The DownloadItem will not have any `WebContents` associated with it and the initial state will be `interrupted`. The download will start only when the `resume` API is called on the DownloadItem.
+	**/
+	function createInterruptedDownload(options:{ /**
+		Absolute path of the download.
+	**/
+	var path : String; /**
+		Complete URL chain for the download.
+	**/
+	var urlChain : Array<String>; @:optional
+	var mimeType : String; /**
+		Start range for the download.
+	**/
+	var offset : Int; /**
+		Total length of the download.
+	**/
+	var length : Int; /**
+		Last-Modified header value.
+	**/
+	@:optional
+	var lastModified : String; /**
+		ETag header value.
+	**/
+	@:optional
+	var eTag : String; /**
+		Time when download was started in number of seconds since UNIX epoch.
+	**/
+	@:optional
+	var startTime : Float; }):Void;
+	/**
+		resolves when the session’s HTTP authentication cache has been cleared.
+	**/
+	function clearAuthCache():js.lib.Promise<Any>;
+	/**
+		Adds scripts that will be executed on ALL web contents that are associated with this session just before normal `preload` scripts run.
+	**/
+	function setPreloads(preloads:Array<String>):Void;
+	/**
+		an array of paths to preload scripts that have been registered.
+	**/
+	function getPreloads():Array<String>;
+	/**
+		The built in spellchecker does not automatically detect what language a user is typing in.  In order for the spell checker to correctly check their words you must call this API with an array of language codes.  You can get the list of supported language codes with the `ses.availableSpellCheckerLanguages` property.
+		
+		**Note:** On macOS the OS spellchecker is used and will detect your language automatically.  This API is a no-op on macOS.
+	**/
+	function setSpellCheckerLanguages(languages:Array<String>):Void;
+	/**
+		An array of language codes the spellchecker is enabled for.  If this list is empty the spellchecker will fallback to using `en-US`.  By default on launch if this setting is an empty list Electron will try to populate this setting with the current OS locale.  This setting is persisted across restarts.
+		
+		**Note:** On macOS the OS spellchecker is used and has its own list of languages.  This API is a no-op on macOS.
+	**/
+	function getSpellCheckerLanguages():Array<String>;
+	/**
+		By default Electron will download hunspell dictionaries from the Chromium CDN.  If you want to override this behavior you can use this API to point the dictionary downloader at your own hosted version of the hunspell dictionaries.  We publish a `hunspell_dictionaries.zip` file with each release which contains the files you need to host here, the file server must be **case insensitive** you must upload each file twice, once with the case it has in the ZIP file and once with the filename as all lower case.
+		
+		If the files present in `hunspell_dictionaries.zip` are available at `https://example.com/dictionaries/language-code.bdic` then you should call this api with `ses.setSpellCheckerDictionaryDownloadURL('https://example.com/dictionaries/')`.  Please note the trailing slash.  The URL to the dictionaries is formed as `${url}${filename}`.
+		
+		**Note:** On macOS the OS spellchecker is used and therefore we do not download any dictionary files.  This API is a no-op on macOS.
+	**/
+	function setSpellCheckerDictionaryDownloadURL(url:String):Void;
+	/**
+		An array of all words in app's custom dictionary. Resolves when the full dictionary is loaded from disk.
+	**/
+	function listWordsInSpellCheckerDictionary():js.lib.Promise<Any>;
+	/**
+		Whether the word was successfully written to the custom dictionary. This API will not work on non-persistent (in-memory) sessions.
+		
+		**Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
+	**/
+	function addWordToSpellCheckerDictionary(word:String):Bool;
+	/**
+		Whether the word was successfully removed from the custom dictionary. This API will not work on non-persistent (in-memory) sessions.
+		
+		**Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
+	**/
+	function removeWordFromSpellCheckerDictionary(word:String):Bool;
+	/**
+		resolves when the extension is loaded.
+		
+		This method will raise an exception if the extension could not be loaded. If there are warnings when installing the extension (e.g. if the extension requests an API that Electron does not support) then they will be logged to the console.
+		
+		Note that Electron does not support the full range of Chrome extensions APIs. See Supported Extensions APIs for more details on what is supported.
+		
+		Note that in previous versions of Electron, extensions that were loaded would be remembered for future runs of the application. This is no longer the case: `loadExtension` must be called on every boot of your app if you want the extension to be loaded.
+		
+		This API does not support loading packed (.crx) extensions.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+		
+		**Note:** Loading extensions into in-memory (non-persistent) sessions is not supported and will throw an error.
+	**/
+	function loadExtension(path:String):js.lib.Promise<Any>;
+	/**
+		Unloads an extension.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+	**/
+	function removeExtension(extensionId:String):Void;
+	/**
+		| `null` - The loaded extension with the given ID.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+	**/
+	function getExtension(extensionId:String):electron.Extension;
+	/**
+		A list of all loaded extensions.
+		
+		**Note:** This API cannot be called before the `ready` event of the `app` module is emitted.
+	**/
+	function getAllExtensions():Array<electron.Extension>;
+}
+@:enum abstract SessionEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when Electron is about to download `item` in `webContents`.
+		
+		Calling `event.preventDefault()` will cancel the download and `item` will not be available from next tick of the process.
+	**/
+	var will_download : electron.main.SessionEvent<Void -> Void> = "will-download";
+	/**
+		Emitted when a render process requests preconnection to a URL, generally due to a resource hint.
+	**/
+	var preconnect : electron.main.SessionEvent<Void -> Void> = "preconnect";
+	/**
+		Emitted when a hunspell dictionary file has been successfully initialized. This occurs after the file has been downloaded.
+	**/
+	var spellcheck_dictionary_initialized : electron.main.SessionEvent<Void -> Void> = "spellcheck-dictionary-initialized";
+	/**
+		Emitted when a hunspell dictionary file starts downloading
+	**/
+	var spellcheck_dictionary_download_begin : electron.main.SessionEvent<Void -> Void> = "spellcheck-dictionary-download-begin";
+	/**
+		Emitted when a hunspell dictionary file has been successfully downloaded
+	**/
+	var spellcheck_dictionary_download_success : electron.main.SessionEvent<Void -> Void> = "spellcheck-dictionary-download-success";
+	/**
+		Emitted when a hunspell dictionary file download fails.  For details on the failure you should collect a netlog and inspect the download request.
+	**/
+	var spellcheck_dictionary_download_failure : electron.main.SessionEvent<Void -> Void> = "spellcheck-dictionary-download-failure";
+}

--- a/src/electron/remote/SystemPreferences.hx
+++ b/src/electron/remote/SystemPreferences.hx
@@ -1,0 +1,222 @@
+package electron.remote;
+/**
+	> Get system preferences.
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/system-preferences
+**/
+@:jsRequire("electron", "remote.systemPreferences") extern class SystemPreferences extends js.node.events.EventEmitter<electron.main.SystemPreferences> {
+	/**
+		A `String` property that can be `dark`, `light` or `unknown`. It determines the macOS appearance setting for your application. This maps to values in: NSApplication.appearance. Setting this will override the system default as well as the value of `getEffectiveAppearance`.
+		
+		Possible values that can be set are `dark` and `light`, and possible return values are `dark`, `light`, and `unknown`.
+		
+		This property is only available on macOS 10.14 Mojave or newer.
+	**/
+	static var appLevelAppearance : String;
+	/**
+		A `String` property that can be `dark`, `light` or `unknown`.
+		
+		Returns the macOS appearance setting that is currently applied to your application, maps to NSApplication.effectiveAppearance
+	**/
+	static var effectiveAppearance : String;
+	/**
+		Whether the system is in Dark Mode.
+		
+		**Note:** On macOS 10.15 Catalina in order for this API to return the correct value when in the "automatic" dark mode setting you must either have `NSRequiresAquaSystemAppearance=false` in your `Info.plist` or be on Electron `>=7.0.0`.  See the dark mode guide for more information.
+		
+		**Deprecated:** Should use the new `nativeTheme.shouldUseDarkColors` API.
+	**/
+	static function isDarkMode():Bool;
+	/**
+		Whether the Swipe between pages setting is on.
+	**/
+	static function isSwipeTrackingFromScrollEventsEnabled():Bool;
+	/**
+		Posts `event` as native notifications of macOS. The `userInfo` is an Object that contains the user information dictionary sent along with the notification.
+	**/
+	static function postNotification(event:String, userInfo:Record, ?deliverImmediately:Bool):Void;
+	/**
+		Posts `event` as native notifications of macOS. The `userInfo` is an Object that contains the user information dictionary sent along with the notification.
+	**/
+	static function postLocalNotification(event:String, userInfo:Record):Void;
+	/**
+		Posts `event` as native notifications of macOS. The `userInfo` is an Object that contains the user information dictionary sent along with the notification.
+	**/
+	static function postWorkspaceNotification(event:String, userInfo:Record):Void;
+	/**
+		The ID of this subscription
+		
+		Subscribes to native notifications of macOS, `callback` will be called with `callback(event, userInfo)` when the corresponding `event` happens. The `userInfo` is an Object that contains the user information dictionary sent along with the notification. The `object` is the sender of the notification, and only supports `NSString` values for now.
+		
+		The `id` of the subscriber is returned, which can be used to unsubscribe the `event`.
+		
+		Under the hood this API subscribes to `NSDistributedNotificationCenter`, example values of `event` are:
+		
+		* `AppleInterfaceThemeChangedNotification`
+		* `AppleAquaColorVariantChanged`
+		* `AppleColorPreferencesChangedNotification`
+		* `AppleShowScrollBarsSettingChanged`
+	**/
+	static function subscribeNotification(event:String, callback:haxe.Constraints.Function):Float;
+	/**
+		The ID of this subscription
+		
+		Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults. This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
+	**/
+	static function subscribeLocalNotification(event:String, callback:haxe.Constraints.Function):Float;
+	/**
+		Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter`. This is necessary for events such as `NSWorkspaceDidActivateApplicationNotification`.
+	**/
+	static function subscribeWorkspaceNotification(event:String, callback:haxe.Constraints.Function):Void;
+	/**
+		Removes the subscriber with `id`.
+	**/
+	static function unsubscribeNotification(id:Int):Void;
+	/**
+		Same as `unsubscribeNotification`, but removes the subscriber from `NSNotificationCenter`.
+	**/
+	static function unsubscribeLocalNotification(id:Int):Void;
+	/**
+		Same as `unsubscribeNotification`, but removes the subscriber from `NSWorkspace.sharedWorkspace.notificationCenter`.
+	**/
+	static function unsubscribeWorkspaceNotification(id:Int):Void;
+	/**
+		Add the specified defaults to your application's `NSUserDefaults`.
+	**/
+	static function registerDefaults(defaults:Record):Void;
+	/**
+		The value of `key` in `NSUserDefaults`.
+		
+		Some popular `key` and `type`s are:
+		
+		* `AppleInterfaceStyle`: `string`
+		* `AppleAquaColorVariant`: `integer`
+		* `AppleHighlightColor`: `string`
+		* `AppleShowScrollBars`: `string`
+		* `NSNavRecentPlaces`: `array`
+		* `NSPreferredWebServices`: `dictionary`
+		* `NSUserDictionaryReplacementItems`: `array`
+	**/
+	static function getUserDefault(key:String, type:String):Any;
+	/**
+		Set the value of `key` in `NSUserDefaults`.
+		
+		Note that `type` should match actual type of `value`. An exception is thrown if they don't.
+		
+		Some popular `key` and `type`s are:
+		
+		* `ApplePressAndHoldEnabled`: `boolean`
+	**/
+	static function setUserDefault(key:String, type:String, value:String):Void;
+	/**
+		Removes the `key` in `NSUserDefaults`. This can be used to restore the default or global value of a `key` previously set with `setUserDefault`.
+	**/
+	static function removeUserDefault(key:String):Void;
+	/**
+		`true` if DWM composition (Aero Glass) is enabled, and `false` otherwise.
+		
+		An example of using it to determine if you should create a transparent window or not (transparent windows won't work correctly when DWM composition is disabled):
+	**/
+	static function isAeroGlassEnabled():Bool;
+	/**
+		The users current system wide accent color preference in RGBA hexadecimal form.
+		
+		This API is only available on macOS 10.14 Mojave or newer.
+	**/
+	static function getAccentColor():String;
+	/**
+		The system color setting in RGB hexadecimal form (`#ABCDEF`). See the Windows docs and the macOS docs for more details.
+		
+		The following colors are only available on macOS 10.14: `find-highlight`, `selected-content-background`, `separator`, `unemphasized-selected-content-background`, `unemphasized-selected-text-background`, and `unemphasized-selected-text`.
+	**/
+	static function getColor(color:String):String;
+	/**
+		The standard system color formatted as `#RRGGBBAA`.
+		
+		Returns one of several standard system colors that automatically adapt to vibrancy and changes in accessibility settings like 'Increase contrast' and 'Reduce transparency'. See Apple Documentation for  more details.
+	**/
+	static function getSystemColor(color:String):String;
+	/**
+		`true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is active, `false` otherwise.
+		
+		**Deprecated:** Should use the new `nativeTheme.shouldUseInvertedColorScheme` API.
+	**/
+	static function isInvertedColorScheme():Bool;
+	/**
+		`true` if a high contrast theme is active, `false` otherwise.
+		
+		**Deprecated:** Should use the new `nativeTheme.shouldUseHighContrastColors` API.
+	**/
+	static function isHighContrastColorScheme():Bool;
+	/**
+		Can be `dark`, `light` or `unknown`.
+		
+		Gets the macOS appearance setting that is currently applied to your application, maps to NSApplication.effectiveAppearance
+	**/
+	static function getEffectiveAppearance():String;
+	/**
+		| `null` - Can be `dark`, `light` or `unknown`.
+		
+		Gets the macOS appearance setting that you have declared you want for your application, maps to NSApplication.appearance. You can use the `setAppLevelAppearance` API to set this value.
+	**/
+	static function getAppLevelAppearance():String;
+	/**
+		Sets the appearance setting for your application, this should override the system default and override the value of `getEffectiveAppearance`.
+	**/
+	static function setAppLevelAppearance(appearance:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		whether or not this device has the ability to use Touch ID.
+		
+		**NOTE:** This API will return `false` on macOS systems older than Sierra 10.12.2.
+	**/
+	static function canPromptTouchID():Bool;
+	/**
+		resolves if the user has successfully authenticated with Touch ID.
+		
+		This API itself will not protect your user data; rather, it is a mechanism to allow you to do so. Native apps will need to set Access Control Constants like `kSecAccessControlUserPresence` on their keychain entry so that reading it would auto-prompt for Touch ID biometric consent. This could be done with `node-keytar`, such that one would store an encryption key with `node-keytar` and only fetch it if `promptTouchID()` resolves.
+		
+		**NOTE:** This API will return a rejected Promise on macOS systems older than Sierra 10.12.2.
+	**/
+	static function promptTouchID(reason:String):js.lib.Promise<Any>;
+	/**
+		`true` if the current process is a trusted accessibility client and `false` if it is not.
+	**/
+	static function isTrustedAccessibilityClient(prompt:Bool):Bool;
+	/**
+		Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
+		
+		This user consent was not required on macOS 10.13 High Sierra or lower so this method will always return `granted`. macOS 10.14 Mojave or higher requires consent for `microphone` and `camera` access. macOS 10.15 Catalina or higher requires consent for `screen` access.
+		
+		Windows 10 has a global setting controlling `microphone` and `camera` access for all win32 applications. It will always return `granted` for `screen` and for all media types on older versions of Windows.
+	**/
+	static function getMediaAccessStatus(mediaType:String):String;
+	/**
+		A promise that resolves with `true` if consent was granted and `false` if it was denied. If an invalid `mediaType` is passed, the promise will be rejected. If an access request was denied and later is changed through the System Preferences pane, a restart of the app will be required for the new permissions to take effect. If access has already been requested and denied, it _must_ be changed through the preference pane; an alert will not pop up and the promise will resolve with the existing access status.
+		
+		**Important:** In order to properly leverage this API, you must set the `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See Electron Application Distribution for more information about how to set these in the context of Electron.
+		
+		This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` if your system is running 10.13 High Sierra or lower.
+	**/
+	static function askForMediaAccess(mediaType:String):js.lib.Promise<Any>;
+	/**
+		* `shouldRenderRichAnimation` Boolean - Returns true if rich animations should be rendered. Looks at session type (e.g. remote desktop) and accessibility settings to give guidance for heavy animations.
+		* `scrollAnimationsEnabledBySystem` Boolean - Determines on a per-platform basis whether scroll animations (e.g. produced by home/end key) should be enabled.
+		* `prefersReducedMotion` Boolean - Determines whether the user desires reduced motion based on platform APIs.
+		
+		Returns an object with system animation settings.
+	**/
+	static function getAnimationSettings():Any;
+}
+@:enum abstract SystemPreferencesEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	var accent_color_changed : electron.main.SystemPreferencesEvent<Void -> Void> = "accent-color-changed";
+	var color_changed : electron.main.SystemPreferencesEvent<Void -> Void> = "color-changed";
+	/**
+		**Deprecated:** Should use the new `updated` event on the `nativeTheme` module.
+	**/
+	var inverted_color_scheme_changed : electron.main.SystemPreferencesEvent<Void -> Void> = "inverted-color-scheme-changed";
+	/**
+		**Deprecated:** Should use the new `updated` event on the `nativeTheme` module.
+	**/
+	var high_contrast_color_scheme_changed : electron.main.SystemPreferencesEvent<Void -> Void> = "high-contrast-color-scheme-changed";
+}

--- a/src/electron/remote/TouchBar.hx
+++ b/src/electron/remote/TouchBar.hx
@@ -1,0 +1,19 @@
+package electron.remote;
+/**
+	> Create TouchBar layouts for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar
+**/
+@:jsRequire("electron", "remote.TouchBar") extern class TouchBar extends js.node.events.EventEmitter<electron.main.TouchBar> {
+	/**
+		A `TouchBarItem` that will replace the "esc" button on the touch bar when set. Setting to `null` restores the default "esc" button. Changing this value immediately updates the escape item in the touch bar.
+	**/
+	var escapeItem : Dynamic;
+	function new(options:{ @:optional
+	var items : Array<haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, Dynamic>>>>>>>>>; @:optional
+	var escapeItem : haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, Dynamic>>>>>>>>>; }):Void;
+}
+@:enum abstract TouchBarEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarButton.hx
+++ b/src/electron/remote/TouchBarButton.hx
@@ -1,0 +1,65 @@
+package electron.remote;
+/**
+	> Create a button in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-button
+**/
+@:jsRequire("electron", "remote.TouchBarButton") extern class TouchBarButton extends js.node.events.EventEmitter<electron.main.TouchBarButton> {
+	/**
+		A `String` representing the description of the button to be read by a screen reader. Will only be read by screen readers if no label is set.
+	**/
+	var accessibilityLabel : String;
+	/**
+		A `String` representing the button's current text. Changing this value immediately updates the button in the touch bar.
+	**/
+	var label : String;
+	/**
+		A `String` hex code representing the button's current background color. Changing this value immediately updates the button in the touch bar.
+	**/
+	var backgroundColor : String;
+	/**
+		A `NativeImage` representing the button's current icon. Changing this value immediately updates the button in the touch bar.
+	**/
+	var icon : electron.NativeImage;
+	/**
+		A `String` - Can be `left`, `right` or `overlay`.  Defaults to `overlay`.
+	**/
+	var iconPosition : String;
+	/**
+		A `Boolean` representing whether the button is in an enabled state.
+	**/
+	var enabled : Bool;
+	function new(options:{ /**
+		Button text.
+	**/
+	@:optional
+	var label : String; /**
+		A short description of the button for use by screenreaders like VoiceOver.
+	**/
+	@:optional
+	var accessibilityLabel : String; /**
+		Button background color in hex format, i.e `#ABCDEF`.
+	**/
+	@:optional
+	var backgroundColor : String; /**
+		Button icon.
+	**/
+	@:optional
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		Can be `left`, `right` or `overlay`. Defaults to `overlay`.
+	**/
+	@:optional
+	var iconPosition : String; /**
+		Function to call when the button is clicked.
+	**/
+	@:optional
+	var click : haxe.Constraints.Function; /**
+		Whether the button is in an enabled state.  Default is `true`.
+	**/
+	@:optional
+	var enabled : Bool; }):Void;
+}
+@:enum abstract TouchBarButtonEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarColorPicker.hx
+++ b/src/electron/remote/TouchBarColorPicker.hx
@@ -1,0 +1,33 @@
+package electron.remote;
+/**
+	> Create a color picker in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-color-picker
+**/
+@:jsRequire("electron", "remote.TouchBarColorPicker") extern class TouchBarColorPicker extends js.node.events.EventEmitter<electron.main.TouchBarColorPicker> {
+	/**
+		A `String[]` array representing the color picker's available colors to select. Changing this value immediately updates the color picker in the touch bar.
+	**/
+	var availableColors : Array<String>;
+	/**
+		A `String` hex code representing the color picker's currently selected color. Changing this value immediately updates the color picker in the touch bar.
+	**/
+	var selectedColor : String;
+	function new(options:{ /**
+		Array of hex color strings to appear as possible colors to select.
+	**/
+	@:optional
+	var availableColors : Array<String>; /**
+		The selected hex color in the picker, i.e `#ABCDEF`.
+	**/
+	@:optional
+	var selectedColor : String; /**
+		Function to call when a color is selected.
+	**/
+	@:optional
+	var change : haxe.Constraints.Function; }):Void;
+}
+@:enum abstract TouchBarColorPickerEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarGroup.hx
+++ b/src/electron/remote/TouchBarGroup.hx
@@ -1,0 +1,16 @@
+package electron.remote;
+/**
+	> Create a group in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-group
+**/
+@:jsRequire("electron", "remote.TouchBarGroup") extern class TouchBarGroup extends js.node.events.EventEmitter<electron.main.TouchBarGroup> {
+	function new(options:{ /**
+		Items to display as a group.
+	**/
+	var items : electron.main.TouchBar; }):Void;
+}
+@:enum abstract TouchBarGroupEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarLabel.hx
+++ b/src/electron/remote/TouchBarLabel.hx
@@ -1,0 +1,37 @@
+package electron.remote;
+/**
+	> Create a label in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-label
+**/
+@:jsRequire("electron", "remote.TouchBarLabel") extern class TouchBarLabel extends js.node.events.EventEmitter<electron.main.TouchBarLabel> {
+	/**
+		A `String` representing the label's current text. Changing this value immediately updates the label in the touch bar.
+	**/
+	var label : String;
+	/**
+		A `String` representing the description of the label to be read by a screen reader.
+	**/
+	var accessibilityLabel : String;
+	/**
+		A `String` hex code representing the label's current text color. Changing this value immediately updates the label in the touch bar.
+	**/
+	var textColor : String;
+	function new(options:{ /**
+		Text to display.
+	**/
+	@:optional
+	var label : String; /**
+		A short description of the button for use by screenreaders like VoiceOver.
+	**/
+	@:optional
+	var accessibilityLabel : String; /**
+		Hex color of text, i.e `#ABCDEF`.
+	**/
+	@:optional
+	var textColor : String; }):Void;
+}
+@:enum abstract TouchBarLabelEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarOtherItemsProxy.hx
+++ b/src/electron/remote/TouchBarOtherItemsProxy.hx
@@ -1,0 +1,15 @@
+package electron.remote;
+/**
+	> Instantiates a special "other items proxy", which nests TouchBar elements inherited from Chromium at the space indicated by the proxy. By default, this proxy is added to each TouchBar at the end of the input. For more information, see the AppKit docs on NSTouchBarItemIdentifierOtherItemsProxy
+	
+	Note: Only one instance of this class can be added per TouchBar.
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-other-items-proxy
+**/
+@:jsRequire("electron", "remote.TouchBarOtherItemsProxy") extern class TouchBarOtherItemsProxy extends js.node.events.EventEmitter<electron.main.TouchBarOtherItemsProxy> {
+	function new():Void;
+}
+@:enum abstract TouchBarOtherItemsProxyEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarPopover.hx
+++ b/src/electron/remote/TouchBarPopover.hx
@@ -1,0 +1,36 @@
+package electron.remote;
+/**
+	> Create a popover in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-popover
+**/
+@:jsRequire("electron", "remote.TouchBarPopover") extern class TouchBarPopover extends js.node.events.EventEmitter<electron.main.TouchBarPopover> {
+	/**
+		A `String` representing the popover's current button text. Changing this value immediately updates the popover in the touch bar.
+	**/
+	var label : String;
+	/**
+		A `NativeImage` representing the popover's current button icon. Changing this value immediately updates the popover in the touch bar.
+	**/
+	var icon : electron.NativeImage;
+	function new(options:{ /**
+		Popover button text.
+	**/
+	@:optional
+	var label : String; /**
+		Popover button icon.
+	**/
+	@:optional
+	var icon : electron.NativeImage; /**
+		Items to display in the popover.
+	**/
+	var items : electron.main.TouchBar; /**
+		`true` to display a close button on the left of the popover, `false` to not show it. Default is `true`.
+	**/
+	@:optional
+	var showCloseButton : Bool; }):Void;
+}
+@:enum abstract TouchBarPopoverEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarScrubber.hx
+++ b/src/electron/remote/TouchBarScrubber.hx
@@ -1,0 +1,79 @@
+package electron.remote;
+/**
+	> Create a scrubber (a scrollable selector)
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-scrubber
+**/
+@:jsRequire("electron", "remote.TouchBarScrubber") extern class TouchBarScrubber extends js.node.events.EventEmitter<electron.main.TouchBarScrubber> {
+	/**
+		A `ScrubberItem[]` array representing the items in this scrubber. Updating this value immediately updates the control in the touch bar. Updating deep properties inside this array **does not update the touch bar**.
+	**/
+	var items : Array<electron.ScrubberItem>;
+	/**
+		A `String` representing the style that selected items in the scrubber should have. Updating this value immediately updates the control in the touch bar. Possible values:
+		
+		* `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
+		* `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
+		* `none` - Removes all styles.
+	**/
+	var selectedStyle : String;
+	/**
+		A `String` representing the style that selected items in the scrubber should have. This style is overlayed on top of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the touch bar. Possible values:
+		
+		* `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
+		* `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
+		* `none` - Removes all styles.
+	**/
+	var overlayStyle : String;
+	/**
+		A `Boolean` representing whether to show the left / right selection arrows in this scrubber. Updating this value immediately updates the control in the touch bar.
+	**/
+	var showArrowButtons : Bool;
+	/**
+		A `String` representing the mode of this scrubber. Updating this value immediately updates the control in the touch bar. Possible values:
+		
+		* `fixed` - Maps to `NSScrubberModeFixed`.
+		* `free` - Maps to `NSScrubberModeFree`.
+	**/
+	var mode : String;
+	/**
+		A `Boolean` representing whether this scrubber is continuous or not. Updating this value immediately updates the control in the touch bar.
+	**/
+	var continuous : Bool;
+	function new(options:{ /**
+		An array of items to place in this scrubber.
+	**/
+	var items : Array<electron.ScrubberItem>; /**
+		Called when the user taps an item that was not the last tapped item.
+	**/
+	@:optional
+	var select : haxe.Constraints.Function; /**
+		Called when the user taps any item.
+	**/
+	@:optional
+	var highlight : haxe.Constraints.Function; /**
+		Selected item style. Can be `background`, `outline` or `none`. Defaults to `none`.
+	**/
+	@:optional
+	var selectedStyle : String; /**
+		Selected overlay item style. Can be `background`, `outline` or `none`. Defaults to `none`.
+	**/
+	@:optional
+	var overlayStyle : String; /**
+		Defaults to `false`.
+	**/
+	@:optional
+	var showArrowButtons : Bool; /**
+		Can be `fixed` or `free`. The default is `free`.
+	**/
+	@:optional
+	var mode : String; /**
+		Defaults to `true`.
+	**/
+	@:optional
+	var continuous : Bool; }):Void;
+}
+@:enum abstract TouchBarScrubberEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarSegmentedControl.hx
+++ b/src/electron/remote/TouchBarSegmentedControl.hx
@@ -1,0 +1,48 @@
+package electron.remote;
+/**
+	> Create a segmented control (a button group) where one button has a selected state
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-segmented-control
+**/
+@:jsRequire("electron", "remote.TouchBarSegmentedControl") extern class TouchBarSegmentedControl extends js.node.events.EventEmitter<electron.main.TouchBarSegmentedControl> {
+	/**
+		A `String` representing the controls current segment style. Updating this value immediately updates the control in the touch bar.
+	**/
+	var segmentStyle : String;
+	/**
+		A `SegmentedControlSegment[]` array representing the segments in this control. Updating this value immediately updates the control in the touch bar. Updating deep properties inside this array **does not update the touch bar**.
+	**/
+	var segments : Array<electron.SegmentedControlSegment>;
+	/**
+		An `Integer` representing the currently selected segment. Changing this value immediately updates the control in the touch bar. User interaction with the touch bar will update this value automatically.
+	**/
+	var selectedIndex : Int;
+	/**
+		A `String` representing the current selection mode of the control.  Can be `single`, `multiple` or `buttons`.
+	**/
+	var mode : String;
+	function new(options:{ /**
+		Style of the segments:
+	**/
+	@:optional
+	var segmentStyle : String; /**
+		The selection mode of the control:
+	**/
+	@:optional
+	var mode : String; /**
+		An array of segments to place in this control.
+	**/
+	var segments : Array<electron.SegmentedControlSegment>; /**
+		The index of the currently selected segment, will update automatically with user interaction. When the mode is `multiple` it will be the last selected item.
+	**/
+	@:optional
+	var selectedIndex : Int; /**
+		Called when the user selects a new segment.
+	**/
+	@:optional
+	var change : haxe.Constraints.Function; }):Void;
+}
+@:enum abstract TouchBarSegmentedControlEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarSlider.hx
+++ b/src/electron/remote/TouchBarSlider.hx
@@ -1,0 +1,49 @@
+package electron.remote;
+/**
+	> Create a slider in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-slider
+**/
+@:jsRequire("electron", "remote.TouchBarSlider") extern class TouchBarSlider extends js.node.events.EventEmitter<electron.main.TouchBarSlider> {
+	/**
+		A `String` representing the slider's current text. Changing this value immediately updates the slider in the touch bar.
+	**/
+	var label : String;
+	/**
+		A `Number` representing the slider's current value. Changing this value immediately updates the slider in the touch bar.
+	**/
+	var value : Float;
+	/**
+		A `Number` representing the slider's current minimum value. Changing this value immediately updates the slider in the touch bar.
+	**/
+	var minValue : Float;
+	/**
+		A `Number` representing the slider's current maximum value. Changing this value immediately updates the slider in the touch bar.
+	**/
+	var maxValue : Float;
+	function new(options:{ /**
+		Label text.
+	**/
+	@:optional
+	var label : String; /**
+		Selected value.
+	**/
+	@:optional
+	var value : Int; /**
+		Minimum value.
+	**/
+	@:optional
+	var minValue : Int; /**
+		Maximum value.
+	**/
+	@:optional
+	var maxValue : Int; /**
+		Function to call when the slider is changed.
+	**/
+	@:optional
+	var change : haxe.Constraints.Function; }):Void;
+}
+@:enum abstract TouchBarSliderEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/TouchBarSpacer.hx
+++ b/src/electron/remote/TouchBarSpacer.hx
@@ -1,0 +1,21 @@
+package electron.remote;
+/**
+	> Create a spacer between two items in the touch bar for native macOS applications
+	
+	Process: Main
+	@see https://electronjs.org/docs/api/touch-bar-spacer
+**/
+@:jsRequire("electron", "remote.TouchBarSpacer") extern class TouchBarSpacer extends js.node.events.EventEmitter<electron.main.TouchBarSpacer> {
+	/**
+		A `String` representing the size of the spacer.  Can be `small`, `large` or `flexible`.
+	**/
+	var size : String;
+	function new(options:{ /**
+		Size of spacer, possible values are:
+	**/
+	@:optional
+	var size : String; }):Void;
+}
+@:enum abstract TouchBarSpacerEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}

--- a/src/electron/remote/Tray.hx
+++ b/src/electron/remote/Tray.hx
@@ -1,0 +1,224 @@
+package electron.remote;
+/**
+	> Add icons and context menus to the system's notification area.
+	
+	Process: Main
+	
+	`Tray` is an EventEmitter.
+	
+	```
+	const { app, Menu, Tray } = require('electron')
+	
+	let tray = null
+	app.whenReady().then(() => {
+	  tray = new Tray('/path/to/my/icon')
+	  const contextMenu = Menu.buildFromTemplate([
+	    { label: 'Item1', type: 'radio' },
+	    { label: 'Item2', type: 'radio' },
+	    { label: 'Item3', type: 'radio', checked: true },
+	    { label: 'Item4', type: 'radio' }
+	  ])
+	  tray.setToolTip('This is my application.')
+	  tray.setContextMenu(contextMenu)
+	})
+	```
+	
+	__Platform limitations:__
+	
+	* On Linux the app indicator will be used if it is supported, otherwise `GtkStatusIcon` will be used instead.
+	* On Linux distributions that only have app indicator support, you have to install `libappindicator1` to make the tray icon work.
+	* App indicator will only be shown when it has a context menu.
+	* When app indicator is used on Linux, the `click` event is ignored.
+	* On Linux in order for changes made to individual `MenuItem`s to take effect, you have to call `setContextMenu` again. For example:
+	
+	```
+	const { app, Menu, Tray } = require('electron')
+	
+	let appIcon = null
+	app.whenReady().then(() => {
+	  appIcon = new Tray('/path/to/my/icon')
+	  const contextMenu = Menu.buildFromTemplate([
+	    { label: 'Item1', type: 'radio' },
+	    { label: 'Item2', type: 'radio' }
+	  ])
+	
+	  // Make a change to the context menu
+	  contextMenu.items[1].checked = false
+	
+	  // Call this again for Linux because we modified the context menu
+	  appIcon.setContextMenu(contextMenu)
+	})
+	```
+	
+	* On Windows it is recommended to use `ICO` icons to get best visual effects.
+	
+	If you want to keep exact same behaviors on all platforms, you should not rely on the `click` event and always attach a context menu to the tray icon.
+	@see https://electronjs.org/docs/api/tray
+**/
+@:jsRequire("electron", "remote.Tray") extern class Tray extends js.node.events.EventEmitter<electron.main.Tray> {
+	function new(image:haxe.extern.EitherType<Dynamic, Dynamic>, ?guid:String):Void;
+	/**
+		Destroys the tray icon immediately.
+	**/
+	function destroy():Void;
+	/**
+		Sets the `image` associated with this tray icon.
+	**/
+	function setImage(image:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Sets the `image` associated with this tray icon when pressed on macOS.
+	**/
+	function setPressedImage(image:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		Sets the hover text for this tray icon.
+	**/
+	function setToolTip(toolTip:String):Void;
+	/**
+		Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
+	**/
+	function setTitle(title:String, ?options:{ /**
+		The font family variant to display, can be `monospaced` or `monospacedDigit`. `monospaced` is available in macOS 10.15+ and `monospacedDigit` is available in macOS 10.11+.  When left blank, the title uses the default system font.
+	**/
+	@:optional
+	var fontType : String; }):Void;
+	/**
+		the title displayed next to the tray icon in the status bar
+	**/
+	function getTitle():String;
+	/**
+		Sets the option to ignore double click events. Ignoring these events allows you to detect every individual click of the tray icon.
+		
+		This value is set to false by default.
+	**/
+	function setIgnoreDoubleClickEvents(ignore:Bool):Void;
+	/**
+		Whether double click events will be ignored.
+	**/
+	function getIgnoreDoubleClickEvents():Bool;
+	/**
+		Displays a tray balloon.
+	**/
+	function displayBalloon(options:{ /**
+		Icon to use when `iconType` is `custom`.
+	**/
+	@:optional
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		Can be `none`, `info`, `warning`, `error` or `custom`. Default is `custom`.
+	**/
+	@:optional
+	var iconType : String; var title : String; var content : String; /**
+		The large version of the icon should be used. Default is `true`. Maps to `NIIF_LARGE_ICON`.
+	**/
+	@:optional
+	var largeIcon : Bool; /**
+		Do not play the associated sound. Default is `false`. Maps to `NIIF_NOSOUND`.
+	**/
+	@:optional
+	var noSound : Bool; /**
+		Do not display the balloon notification if the current user is in "quiet time". Default is `false`. Maps to `NIIF_RESPECT_QUIET_TIME`.
+	**/
+	@:optional
+	var respectQuietTime : Bool; }):Void;
+	/**
+		Removes a tray balloon.
+	**/
+	function removeBalloon():Void;
+	/**
+		Returns focus to the taskbar notification area. Notification area icons should use this message when they have completed their UI operation. For example, if the icon displays a shortcut menu, but the user presses ESC to cancel it, use `tray.focus()` to return focus to the notification area.
+	**/
+	function focus():Void;
+	/**
+		Pops up the context menu of the tray icon. When `menu` is passed, the `menu` will be shown instead of the tray icon's context menu.
+		
+		The `position` is only available on Windows, and it is (0, 0) by default.
+	**/
+	function popUpContextMenu(?menu:electron.main.Menu, ?position:electron.Point):Void;
+	/**
+		Closes an open context menu, as set by `tray.setContextMenu()`.
+	**/
+	function closeContextMenu():Void;
+	/**
+		Sets the context menu for this icon.
+	**/
+	function setContextMenu(menu:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `bounds` of this tray icon as `Object`.
+	**/
+	function getBounds():electron.Rectangle;
+	/**
+		Whether the tray icon is destroyed.
+	**/
+	function isDestroyed():Bool;
+}
+@:enum abstract TrayEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the tray icon is clicked.
+	**/
+	var click : electron.main.TrayEvent<Void -> Void> = "click";
+	/**
+		Emitted when the tray icon is right clicked.
+	**/
+	var right_click : electron.main.TrayEvent<Void -> Void> = "right-click";
+	/**
+		Emitted when the tray icon is double clicked.
+	**/
+	var double_click : electron.main.TrayEvent<Void -> Void> = "double-click";
+	/**
+		Emitted when the tray balloon shows.
+	**/
+	var balloon_show : electron.main.TrayEvent<Void -> Void> = "balloon-show";
+	/**
+		Emitted when the tray balloon is clicked.
+	**/
+	var balloon_click : electron.main.TrayEvent<Void -> Void> = "balloon-click";
+	/**
+		Emitted when the tray balloon is closed because of timeout or user manually closes it.
+	**/
+	var balloon_closed : electron.main.TrayEvent<Void -> Void> = "balloon-closed";
+	/**
+		Emitted when any dragged items are dropped on the tray icon.
+	**/
+	var drop : electron.main.TrayEvent<Void -> Void> = "drop";
+	/**
+		Emitted when dragged files are dropped in the tray icon.
+	**/
+	var drop_files : electron.main.TrayEvent<Void -> Void> = "drop-files";
+	/**
+		Emitted when dragged text is dropped in the tray icon.
+	**/
+	var drop_text : electron.main.TrayEvent<Void -> Void> = "drop-text";
+	/**
+		Emitted when a drag operation enters the tray icon.
+	**/
+	var drag_enter : electron.main.TrayEvent<Void -> Void> = "drag-enter";
+	/**
+		Emitted when a drag operation exits the tray icon.
+	**/
+	var drag_leave : electron.main.TrayEvent<Void -> Void> = "drag-leave";
+	/**
+		Emitted when a drag operation ends on the tray or ends at another location.
+	**/
+	var drag_end : electron.main.TrayEvent<Void -> Void> = "drag-end";
+	/**
+		Emitted when the mouse is released from clicking the tray icon.
+		
+		Note: This will not be emitted if you have set a context menu for your Tray using `tray.setContextMenu`, as a result of macOS-level constraints.
+	**/
+	var mouse_up : electron.main.TrayEvent<Void -> Void> = "mouse-up";
+	/**
+		Emitted when the mouse clicks the tray icon.
+	**/
+	var mouse_down : electron.main.TrayEvent<Void -> Void> = "mouse-down";
+	/**
+		Emitted when the mouse enters the tray icon.
+	**/
+	var mouse_enter : electron.main.TrayEvent<Void -> Void> = "mouse-enter";
+	/**
+		Emitted when the mouse exits the tray icon.
+	**/
+	var mouse_leave : electron.main.TrayEvent<Void -> Void> = "mouse-leave";
+	/**
+		Emitted when the mouse moves in the tray icon.
+	**/
+	var mouse_move : electron.main.TrayEvent<Void -> Void> = "mouse-move";
+}

--- a/src/electron/remote/WebContents.hx
+++ b/src/electron/remote/WebContents.hx
@@ -1,0 +1,1020 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/web-contents
+**/
+@:jsRequire("electron", "remote.WebContents") extern class WebContents extends js.node.events.EventEmitter<electron.main.WebContents> {
+	/**
+		An array of all `WebContents` instances. This will contain web contents for all windows, webviews, opened devtools, and devtools extension background pages.
+	**/
+	static function getAllWebContents():Array<electron.main.WebContents>;
+	/**
+		The web contents that is focused in this application, otherwise returns `null`.
+	**/
+	static function getFocusedWebContents():electron.main.WebContents;
+	/**
+		| undefined - A WebContents instance with the given ID, or `undefined` if there is no WebContents associated with the given ID.
+	**/
+	static function fromId(id:Int):electron.main.WebContents;
+	/**
+		A `Boolean` property that determines whether this page is muted.
+	**/
+	var audioMuted : Bool;
+	/**
+		A `String` property that determines the user agent for this web page.
+	**/
+	var userAgent : String;
+	/**
+		A `Number` property that determines the zoom level for this web contents.
+		
+		The original size is 0 and each increment above or below represents zooming 20% larger or smaller to default limits of 300% and 50% of original size, respectively. The formula for this is `scale := 1.2 ^ level`.
+	**/
+	var zoomLevel : Float;
+	/**
+		A `Number` property that determines the zoom factor for this web contents.
+		
+		The zoom factor is the zoom percent divided by 100, so 300% = 3.0.
+	**/
+	var zoomFactor : Float;
+	/**
+		An `Integer` property that sets the frame rate of the web contents to the specified number. Only values between 1 and 240 are accepted.
+		
+		Only applicable if *offscreen rendering* is enabled.
+	**/
+	var frameRate : Int;
+	/**
+		A `Integer` representing the unique ID of this WebContents. Each ID is unique among all `WebContents` instances of the entire Electron application.
+	**/
+	var id : Int;
+	/**
+		A `Session` used by this webContents.
+	**/
+	var session : electron.main.Session;
+	/**
+		A `WebContents` instance that might own this `WebContents`.
+	**/
+	var hostWebContents : electron.main.WebContents;
+	/**
+		A `WebContents | null` property that represents the of DevTools `WebContents` associated with a given `WebContents`.
+		
+		**Note:** Users should never store this object because it may become `null` when the DevTools has been closed.
+	**/
+	var devToolsWebContents : haxe.extern.EitherType<Dynamic, Dynamic>;
+	/**
+		A `Debugger` instance for this webContents.
+	**/
+	var debugger : electron.main.Debugger;
+	/**
+		A `Boolean` property that determines whether or not this WebContents will throttle animations and timers when the page becomes backgrounded. This also affects the Page Visibility API.
+	**/
+	var backgroundThrottling : Bool;
+	/**
+		the promise will resolve when the page has finished loading (see `did-finish-load`), and rejects if the page fails to load (see `did-fail-load`). A noop rejection handler is already attached, which avoids unhandled rejection errors.
+		
+		Loads the `url` in the window. The `url` must contain the protocol prefix, e.g. the `http://` or `file://`. If the load should bypass http cache then use the `pragma` header to achieve it.
+	**/
+	function loadURL(url:String, ?options:{ /**
+		An HTTP Referrer url.
+	**/
+	@:optional
+	var httpReferrer : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		A user agent originating the request.
+	**/
+	@:optional
+	var userAgent : String; /**
+		Extra headers separated by "\n".
+	**/
+	@:optional
+	var extraHeaders : String; @:optional
+	var postData : haxe.extern.EitherType<Array<Dynamic>, haxe.extern.EitherType<Array<Dynamic>, Array<Dynamic>>>; /**
+		Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
+	**/
+	@:optional
+	var baseURLForDataURL : String; }):js.lib.Promise<Any>;
+	/**
+		the promise will resolve when the page has finished loading (see `did-finish-load`), and rejects if the page fails to load (see `did-fail-load`).
+		
+		Loads the given file in the window, `filePath` should be a path to an HTML file relative to the root of your application.  For instance an app structure like this:
+		
+		Would require code like this
+	**/
+	function loadFile(filePath:String, ?options:{ /**
+		Passed to `url.format()`.
+	**/
+	@:optional
+	var query : Record; /**
+		Passed to `url.format()`.
+	**/
+	@:optional
+	var search : String; /**
+		Passed to `url.format()`.
+	**/
+	@:optional
+	var hash : String; }):js.lib.Promise<Any>;
+	/**
+		Initiates a download of the resource at `url` without navigating. The `will-download` event of `session` will be triggered.
+	**/
+	function downloadURL(url:String):Void;
+	/**
+		The URL of the current web page.
+	**/
+	function getURL():String;
+	/**
+		The title of the current web page.
+	**/
+	function getTitle():String;
+	/**
+		Whether the web page is destroyed.
+	**/
+	function isDestroyed():Bool;
+	/**
+		Focuses the web page.
+	**/
+	function focus():Void;
+	/**
+		Whether the web page is focused.
+	**/
+	function isFocused():Bool;
+	/**
+		Whether web page is still loading resources.
+	**/
+	function isLoading():Bool;
+	/**
+		Whether the main frame (and not just iframes or frames within it) is still loading.
+	**/
+	function isLoadingMainFrame():Bool;
+	/**
+		Whether the web page is waiting for a first-response from the main resource of the page.
+	**/
+	function isWaitingForResponse():Bool;
+	/**
+		Stops any pending navigation.
+	**/
+	function stop():Void;
+	/**
+		Reloads the current web page.
+	**/
+	function reload():Void;
+	/**
+		Reloads current page and ignores cache.
+	**/
+	function reloadIgnoringCache():Void;
+	/**
+		Whether the browser can go back to previous web page.
+	**/
+	function canGoBack():Bool;
+	/**
+		Whether the browser can go forward to next web page.
+	**/
+	function canGoForward():Bool;
+	/**
+		Whether the web page can go to `offset`.
+	**/
+	function canGoToOffset(offset:Int):Bool;
+	/**
+		Clears the navigation history.
+	**/
+	function clearHistory():Void;
+	/**
+		Makes the browser go back a web page.
+	**/
+	function goBack():Void;
+	/**
+		Makes the browser go forward a web page.
+	**/
+	function goForward():Void;
+	/**
+		Navigates browser to the specified absolute web page index.
+	**/
+	function goToIndex(index:Int):Void;
+	/**
+		Navigates to the specified offset from the "current entry".
+	**/
+	function goToOffset(offset:Int):Void;
+	/**
+		Whether the renderer process has crashed.
+	**/
+	function isCrashed():Bool;
+	/**
+		Forcefully terminates the renderer process that is currently hosting this `webContents`. This will cause the `render-process-gone` event to be emitted with the `reason=killed || reason=crashed`. Please note that some webContents share renderer processes and therefore calling this method may also crash the host process for other webContents as well.
+		
+		Calling `reload()` immediately after calling this method will force the reload to occur in a new process. This should be used when this process is unstable or unusable, for instance in order to recover from the `unresponsive` event.
+	**/
+	function forcefullyCrashRenderer():Void;
+	/**
+		Overrides the user agent for this web page.
+	**/
+	function setUserAgent(userAgent:String):Void;
+	/**
+		The user agent for this web page.
+	**/
+	function getUserAgent():String;
+	/**
+		A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via `contents.removeInsertedCSS(key)`.
+		
+		Injects CSS into the current web page and returns a unique key for the inserted stylesheet.
+	**/
+	function insertCSS(css:String, ?options:{ /**
+		Can be either 'user' or 'author'; Specifying 'user' enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
+	**/
+	@:optional
+	var cssOrigin : String; }):js.lib.Promise<Any>;
+	/**
+		Resolves if the removal was successful.
+		
+		Removes the inserted CSS from the current web page. The stylesheet is identified by its key, which is returned from `contents.insertCSS(css)`.
+	**/
+	function removeInsertedCSS(key:String):js.lib.Promise<Any>;
+	/**
+		A promise that resolves with the result of the executed code or is rejected if the result of the code is a rejected promise.
+		
+		Evaluates `code` in page.
+		
+		In the browser window some HTML APIs like `requestFullScreen` can only be invoked by a gesture from the user. Setting `userGesture` to `true` will remove this limitation.
+		
+		Code execution will be suspended until web page stop loading.
+	**/
+	function executeJavaScript(code:String, ?userGesture:Bool):js.lib.Promise<Any>;
+	/**
+		A promise that resolves with the result of the executed code or is rejected if the result of the code is a rejected promise.
+		
+		Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
+	**/
+	function executeJavaScriptInIsolatedWorld(worldId:Int, scripts:Array<electron.WebSource>, ?userGesture:Bool):js.lib.Promise<Any>;
+	/**
+		Ignore application menu shortcuts while this web contents is focused.
+	**/
+	function setIgnoreMenuShortcuts(ignore:Bool):Void;
+	/**
+		Mute the audio on the current web page.
+	**/
+	function setAudioMuted(muted:Bool):Void;
+	/**
+		Whether this page has been muted.
+	**/
+	function isAudioMuted():Bool;
+	/**
+		Whether audio is currently playing.
+	**/
+	function isCurrentlyAudible():Bool;
+	/**
+		Changes the zoom factor to the specified factor. Zoom factor is zoom percent divided by 100, so 300% = 3.0.
+		
+		The factor must be greater than 0.0.
+	**/
+	function setZoomFactor(factor:Float):Void;
+	/**
+		the current zoom factor.
+	**/
+	function getZoomFactor():Float;
+	/**
+		Changes the zoom level to the specified level. The original size is 0 and each increment above or below represents zooming 20% larger or smaller to default limits of 300% and 50% of original size, respectively. The formula for this is `scale := 1.2 ^ level`.
+	**/
+	function setZoomLevel(level:Float):Void;
+	/**
+		the current zoom level.
+	**/
+	function getZoomLevel():Float;
+	/**
+		Sets the maximum and minimum pinch-to-zoom level.
+		
+		> **NOTE**: Visual zoom is disabled by default in Electron. To re-enable it, call:
+	**/
+	function setVisualZoomLevelLimits(minimumLevel:Float, maximumLevel:Float):js.lib.Promise<Any>;
+	/**
+		Executes the editing command `undo` in web page.
+	**/
+	function undo():Void;
+	/**
+		Executes the editing command `redo` in web page.
+	**/
+	function redo():Void;
+	/**
+		Executes the editing command `cut` in web page.
+	**/
+	function cut():Void;
+	/**
+		Executes the editing command `copy` in web page.
+	**/
+	function copy():Void;
+	/**
+		Copy the image at the given position to the clipboard.
+	**/
+	function copyImageAt(x:Int, y:Int):Void;
+	/**
+		Executes the editing command `paste` in web page.
+	**/
+	function paste():Void;
+	/**
+		Executes the editing command `pasteAndMatchStyle` in web page.
+	**/
+	function pasteAndMatchStyle():Void;
+	/**
+		Executes the editing command `delete` in web page.
+	**/
+	function delete():Void;
+	/**
+		Executes the editing command `selectAll` in web page.
+	**/
+	function selectAll():Void;
+	/**
+		Executes the editing command `unselect` in web page.
+	**/
+	function unselect():Void;
+	/**
+		Executes the editing command `replace` in web page.
+	**/
+	function replace(text:String):Void;
+	/**
+		Executes the editing command `replaceMisspelling` in web page.
+	**/
+	function replaceMisspelling(text:String):Void;
+	/**
+		Inserts `text` to the focused element.
+	**/
+	function insertText(text:String):js.lib.Promise<Any>;
+	/**
+		The request id used for the request.
+		
+		Starts a request to find all matches for the `text` in the web page. The result of the request can be obtained by subscribing to `found-in-page` event.
+	**/
+	function findInPage(text:String, ?options:{ /**
+		Whether to search forward or backward, defaults to `true`.
+	**/
+	@:optional
+	var forward : Bool; /**
+		Whether the operation is first request or a follow up, defaults to `false`.
+	**/
+	@:optional
+	var findNext : Bool; /**
+		Whether search should be case-sensitive, defaults to `false`.
+	**/
+	@:optional
+	var matchCase : Bool; /**
+		Whether to look only at the start of words. defaults to `false`.
+	**/
+	@:optional
+	var wordStart : Bool; /**
+		When combined with `wordStart`, accepts a match in the middle of a word if the match begins with an uppercase letter followed by a lowercase or non-letter. Accepts several other intra-word matches, defaults to `false`.
+	**/
+	@:optional
+	var medialCapitalAsWordStart : Bool; }):Int;
+	/**
+		Stops any `findInPage` request for the `webContents` with the provided `action`.
+	**/
+	function stopFindInPage(action:String):Void;
+	/**
+		Resolves with a NativeImage
+		
+		Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
+	**/
+	function capturePage(?rect:electron.Rectangle):js.lib.Promise<Any>;
+	/**
+		Whether this page is being captured. It returns true when the capturer count is large then 0.
+	**/
+	function isBeingCaptured():Bool;
+	/**
+		Increase the capturer count by one. The page is considered visible when its browser window is hidden and the capturer count is non-zero. If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
+		
+		This also affects the Page Visibility API.
+	**/
+	function incrementCapturerCount(?size:electron.Size, ?stayHidden:Bool):Void;
+	/**
+		Decrease the capturer count by one. The page will be set to hidden or occluded state when its browser window is hidden or occluded and the capturer count reaches zero. If you want to decrease the hidden capturer count instead you should set `stayHidden` to true.
+	**/
+	function decrementCapturerCount(?stayHidden:Bool):Void;
+	/**
+		Get the system printer list.
+	**/
+	function getPrinters():Array<electron.PrinterInfo>;
+	/**
+		When a custom `pageSize` is passed, Chromium attempts to validate platform specific minimum values for `width_microns` and `height_microns`. Width and height must both be minimum 353 microns but may be higher on some operating systems.
+		
+		Prints window's web page. When `silent` is set to `true`, Electron will pick the system's default printer if `deviceName` is empty and the default settings for printing.
+		
+		Use `page-break-before: always;` CSS style to force to print to a new page.
+		
+		Example usage:
+	**/
+	function print(?options:{ /**
+		Don't ask user for print settings. Default is `false`.
+	**/
+	@:optional
+	var silent : Bool; /**
+		Prints the background color and image of the web page. Default is `false`.
+	**/
+	@:optional
+	var printBackground : Bool; /**
+		Set the printer device name to use. Must be the system-defined name and not the 'friendly' name, e.g 'Brother_QL_820NWB' and not 'Brother QL-820NWB'.
+	**/
+	@:optional
+	var deviceName : String; /**
+		Set whether the printed web page will be in color or grayscale. Default is `true`.
+	**/
+	@:optional
+	var color : Bool; @:optional
+	var margins : { /**
+		Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
+	**/
+	@:optional
+	var marginType : String; /**
+		The top margin of the printed web page, in pixels.
+	**/
+	@:optional
+	var top : Float; /**
+		The bottom margin of the printed web page, in pixels.
+	**/
+	@:optional
+	var bottom : Float; /**
+		The left margin of the printed web page, in pixels.
+	**/
+	@:optional
+	var left : Float; /**
+		The right margin of the printed web page, in pixels.
+	**/
+	@:optional
+	var right : Float; }; /**
+		Whether the web page should be printed in landscape mode. Default is `false`.
+	**/
+	@:optional
+	var landscape : Bool; /**
+		The scale factor of the web page.
+	**/
+	@:optional
+	var scaleFactor : Float; /**
+		The number of pages to print per page sheet.
+	**/
+	@:optional
+	var pagesPerSheet : Float; /**
+		Whether the web page should be collated.
+	**/
+	@:optional
+	var collate : Bool; /**
+		The number of copies of the web page to print.
+	**/
+	@:optional
+	var copies : Float; /**
+		The page range to print. On macOS, only one range is honored.
+	**/
+	@:optional
+	var pageRanges : Array<{ /**
+	Index of the first page to print (0-based).
+**/
+var from : Float; /**
+	Index of the last page to print (inclusive) (0-based).
+**/
+var to : Float; }>; /**
+		Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
+	**/
+	@:optional
+	var duplexMode : String; @:optional
+	var dpi : Record; /**
+		String to be printed as page header.
+	**/
+	@:optional
+	var header : String; /**
+		String to be printed as page footer.
+	**/
+	@:optional
+	var footer : String; /**
+		Specify page size of the printed document. Can be `A3`, `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`.
+	**/
+	@:optional
+	var pageSize : haxe.extern.EitherType<Dynamic, Dynamic>; }, ?callback:haxe.Constraints.Function):Void;
+	/**
+		Resolves with the generated PDF data.
+		
+		Prints window's web page as PDF with Chromium's preview printing custom settings.
+		
+		The `landscape` will be ignored if `@page` CSS at-rule is used in the web page.
+		
+		By default, an empty `options` will be regarded as:
+		
+		Use `page-break-before: always; ` CSS style to force to print to a new page.
+		
+		An example of `webContents.printToPDF`:
+	**/
+	function printToPDF(options:{ /**
+		the header and footer for the PDF.
+	**/
+	@:optional
+	var headerFooter : Record; /**
+		`true` for landscape, `false` for portrait.
+	**/
+	@:optional
+	var landscape : Bool; /**
+		Specifies the type of margins to use. Uses 0 for default margin, 1 for no margin, and 2 for minimum margin.
+	**/
+	@:optional
+	var marginsType : Int; /**
+		The scale factor of the web page. Can range from 0 to 100.
+	**/
+	@:optional
+	var scaleFactor : Float; /**
+		The page range to print.
+	**/
+	@:optional
+	var pageRanges : Record; /**
+		Specify page size of the generated PDF. Can be `A3`, `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` and `width` in microns.
+	**/
+	@:optional
+	var pageSize : haxe.extern.EitherType<Dynamic, Dynamic>; /**
+		Whether to print CSS backgrounds.
+	**/
+	@:optional
+	var printBackground : Bool; /**
+		Whether to print selection only.
+	**/
+	@:optional
+	var printSelectionOnly : Bool; }):js.lib.Promise<Any>;
+	/**
+		Adds the specified path to DevTools workspace. Must be used after DevTools creation:
+	**/
+	function addWorkSpace(path:String):Void;
+	/**
+		Removes the specified path from DevTools workspace.
+	**/
+	function removeWorkSpace(path:String):Void;
+	/**
+		Uses the `devToolsWebContents` as the target `WebContents` to show devtools.
+		
+		The `devToolsWebContents` must not have done any navigation, and it should not be used for other purposes after the call.
+		
+		By default Electron manages the devtools by creating an internal `WebContents` with native view, which developers have very limited control of. With the `setDevToolsWebContents` method, developers can use any `WebContents` to show the devtools in it, including `BrowserWindow`, `BrowserView` and `<webview>` tag.
+		
+		Note that closing the devtools does not destroy the `devToolsWebContents`, it is caller's responsibility to destroy `devToolsWebContents`.
+		
+		An example of showing devtools in a `<webview>` tag:
+		
+		An example of showing devtools in a `BrowserWindow`:
+	**/
+	function setDevToolsWebContents(devToolsWebContents:electron.main.WebContents):Void;
+	/**
+		Opens the devtools.
+		
+		When `contents` is a `<webview>` tag, the `mode` would be `detach` by default, explicitly passing an empty `mode` can force using last used dock state.
+	**/
+	function openDevTools(?options:{ /**
+		Opens the devtools with specified dock state, can be `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state. In `undocked` mode it's possible to dock back. In `detach` mode it's not.
+	**/
+	var mode : String; /**
+		Whether to bring the opened devtools window to the foreground. The default is `true`.
+	**/
+	@:optional
+	var activate : Bool; }):Void;
+	/**
+		Closes the devtools.
+	**/
+	function closeDevTools():Void;
+	/**
+		Whether the devtools is opened.
+	**/
+	function isDevToolsOpened():Bool;
+	/**
+		Whether the devtools view is focused .
+	**/
+	function isDevToolsFocused():Bool;
+	/**
+		Toggles the developer tools.
+	**/
+	function toggleDevTools():Void;
+	/**
+		Starts inspecting element at position (`x`, `y`).
+	**/
+	function inspectElement(x:Int, y:Int):Void;
+	/**
+		Opens the developer tools for the shared worker context.
+	**/
+	function inspectSharedWorker():Void;
+	/**
+		Inspects the shared worker based on its ID.
+	**/
+	function inspectSharedWorkerById(workerId:String):Void;
+	/**
+		Information about all Shared Workers.
+	**/
+	function getAllSharedWorkers():Array<electron.SharedWorkerInfo>;
+	/**
+		Opens the developer tools for the service worker context.
+	**/
+	function inspectServiceWorker():Void;
+	/**
+		Send an asynchronous message to the renderer process via `channel`, along with arguments. Arguments will be serialized with the Structured Clone Algorithm, just like `postMessage`, so prototype chains will not be included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will throw an exception.
+		
+		> **NOTE**: Sending non-standard JavaScript types such as DOM objects or special Electron objects will throw an exception.
+		
+		The renderer process can handle the message by listening to `channel` with the `ipcRenderer` module.
+		
+		An example of sending messages from the main process to the renderer process:
+	**/
+	function send(channel:String, args:haxe.extern.Rest<Any>):Void;
+	/**
+		Send an asynchronous message to a specific frame in a renderer process via `channel`, along with arguments. Arguments will be serialized with the Structured Clone Algorithm, just like `postMessage`, so prototype chains will not be included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will throw an exception.
+		
+		> **NOTE:** Sending non-standard JavaScript types such as DOM objects or special Electron objects will throw an exception.
+		
+		The renderer process can handle the message by listening to `channel` with the `ipcRenderer` module.
+		
+		If you want to get the `frameId` of a given renderer context you should use the `webFrame.routingId` value.  E.g.
+		
+		You can also read `frameId` from all incoming IPC messages in the main process.
+	**/
+	function sendToFrame(frameId:haxe.extern.EitherType<Dynamic, Dynamic>, channel:String, args:haxe.extern.Rest<Any>):Void;
+	/**
+		Send a message to the renderer process, optionally transferring ownership of zero or more [`MessagePortMain`][] objects.
+		
+		The transferred `MessagePortMain` objects will be available in the renderer process by accessing the `ports` property of the emitted event. When they arrive in the renderer, they will be native DOM `MessagePort` objects.
+		
+		For example:
+	**/
+	function postMessage(channel:String, message:Any, ?transfer:Array<electron.main.MessagePortMain>):Void;
+	/**
+		Enable device emulation with the given parameters.
+	**/
+	function enableDeviceEmulation(parameters:{ /**
+		Specify the screen type to emulate (default: `desktop`):
+	**/
+	var screenPosition : String; /**
+		Set the emulated screen size (screenPosition == mobile).
+	**/
+	var screenSize : electron.Size; /**
+		Position the view on the screen (screenPosition == mobile) (default: `{ x: 0, y: 0 }`).
+	**/
+	var viewPosition : electron.Point; /**
+		Set the device scale factor (if zero defaults to original device scale factor) (default: `0`).
+	**/
+	var deviceScaleFactor : Int; /**
+		Set the emulated view size (empty means no override)
+	**/
+	var viewSize : electron.Size; /**
+		Scale of emulated view inside available space (not in fit to view mode) (default: `1`).
+	**/
+	var scale : Float; }):Void;
+	/**
+		Disable device emulation enabled by `webContents.enableDeviceEmulation`.
+	**/
+	function disableDeviceEmulation():Void;
+	/**
+		Sends an input `event` to the page. **Note:** The `BrowserWindow` containing the contents needs to be focused for `sendInputEvent()` to work.
+	**/
+	function sendInputEvent(inputEvent:haxe.extern.EitherType<Dynamic, haxe.extern.EitherType<Dynamic, Dynamic>>):Void;
+	/**
+		Begin subscribing for presentation events and captured frames, the `callback` will be called with `callback(image, dirtyRect)` when there is a presentation event.
+		
+		The `image` is an instance of NativeImage that stores the captured frame.
+		
+		The `dirtyRect` is an object with `x, y, width, height` properties that describes which part of the page was repainted. If `onlyDirty` is set to `true`, `image` will only contain the repainted area. `onlyDirty` defaults to `false`.
+	**/
+	function beginFrameSubscription(?onlyDirty:Bool, callback:haxe.Constraints.Function):Void;
+	/**
+		End subscribing for frame presentation events.
+	**/
+	function endFrameSubscription():Void;
+	/**
+		Sets the `item` as dragging item for current drag-drop operation, `file` is the absolute path of the file to be dragged, and `icon` is the image showing under the cursor when dragging.
+	**/
+	function startDrag(item:{ /**
+		The path(s) to the file(s) being dragged.
+	**/
+	var file : haxe.extern.EitherType<Array<Dynamic>, Dynamic>; /**
+		The image must be non-empty on macOS.
+	**/
+	var icon : haxe.extern.EitherType<Dynamic, Dynamic>; }):Void;
+	/**
+		resolves if the page is saved.
+	**/
+	function savePage(fullPath:String, saveType:String):js.lib.Promise<Any>;
+	/**
+		Shows pop-up dictionary that searches the selected word on the page.
+	**/
+	function showDefinitionForSelection():Void;
+	/**
+		Indicates whether *offscreen rendering* is enabled.
+	**/
+	function isOffscreen():Bool;
+	/**
+		If *offscreen rendering* is enabled and not painting, start painting.
+	**/
+	function startPainting():Void;
+	/**
+		If *offscreen rendering* is enabled and painting, stop painting.
+	**/
+	function stopPainting():Void;
+	/**
+		If *offscreen rendering* is enabled returns whether it is currently painting.
+	**/
+	function isPainting():Bool;
+	/**
+		If *offscreen rendering* is enabled sets the frame rate to the specified number. Only values between 1 and 240 are accepted.
+	**/
+	function setFrameRate(fps:Int):Void;
+	/**
+		If *offscreen rendering* is enabled returns the current frame rate.
+	**/
+	function getFrameRate():Int;
+	/**
+		Schedules a full repaint of the window this web contents is in.
+		
+		If *offscreen rendering* is enabled invalidates the frame and generates a new one through the `'paint'` event.
+	**/
+	function invalidate():Void;
+	/**
+		Returns the WebRTC IP Handling Policy.
+	**/
+	function getWebRTCIPHandlingPolicy():String;
+	/**
+		Setting the WebRTC IP handling policy allows you to control which IPs are exposed via WebRTC. See BrowserLeaks for more details.
+	**/
+	function setWebRTCIPHandlingPolicy(policy:String):Void;
+	/**
+		The operating system `pid` of the associated renderer process.
+	**/
+	function getOSProcessId():Int;
+	/**
+		The Chromium internal `pid` of the associated renderer. Can be compared to the `frameProcessId` passed by frame specific navigation events (e.g. `did-frame-navigate`)
+	**/
+	function getProcessId():Int;
+	/**
+		Indicates whether the snapshot has been created successfully.
+		
+		Takes a V8 heap snapshot and saves it to `filePath`.
+	**/
+	function takeHeapSnapshot(filePath:String):js.lib.Promise<Any>;
+	/**
+		whether or not this WebContents will throttle animations and timers when the page becomes backgrounded. This also affects the Page Visibility API.
+	**/
+	function getBackgroundThrottling():Bool;
+	/**
+		Controls whether or not this WebContents will throttle animations and timers when the page becomes backgrounded. This also affects the Page Visibility API.
+	**/
+	function setBackgroundThrottling(allowed:Bool):Void;
+	/**
+		the type of the webContent. Can be `backgroundPage`, `window`, `browserView`, `remote`, `webview` or `offscreen`.
+	**/
+	function getType():String;
+}
+@:enum abstract WebContentsEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+	/**
+		Emitted when the navigation is done, i.e. the spinner of the tab has stopped spinning, and the `onload` event was dispatched.
+	**/
+	var did_finish_load : electron.main.WebContentsEvent<Void -> Void> = "did-finish-load";
+	/**
+		This event is like `did-finish-load` but emitted when the load failed. The full list of error codes and their meaning is available here.
+	**/
+	var did_fail_load : electron.main.WebContentsEvent<Void -> Void> = "did-fail-load";
+	/**
+		This event is like `did-fail-load` but emitted when the load was cancelled (e.g. `window.stop()` was invoked).
+	**/
+	var did_fail_provisional_load : electron.main.WebContentsEvent<Void -> Void> = "did-fail-provisional-load";
+	/**
+		Emitted when a frame has done navigation.
+	**/
+	var did_frame_finish_load : electron.main.WebContentsEvent<Void -> Void> = "did-frame-finish-load";
+	/**
+		Corresponds to the points in time when the spinner of the tab started spinning.
+	**/
+	var did_start_loading : electron.main.WebContentsEvent<Void -> Void> = "did-start-loading";
+	/**
+		Corresponds to the points in time when the spinner of the tab stopped spinning.
+	**/
+	var did_stop_loading : electron.main.WebContentsEvent<Void -> Void> = "did-stop-loading";
+	/**
+		Emitted when the document in the given frame is loaded.
+	**/
+	var dom_ready : electron.main.WebContentsEvent<Void -> Void> = "dom-ready";
+	/**
+		Fired when page title is set during navigation. `explicitSet` is false when title is synthesized from file url.
+	**/
+	var page_title_updated : electron.main.WebContentsEvent<Void -> Void> = "page-title-updated";
+	/**
+		Emitted when page receives favicon urls.
+	**/
+	var page_favicon_updated : electron.main.WebContentsEvent<Void -> Void> = "page-favicon-updated";
+	/**
+		Emitted when the page requests to open a new window for a `url`. It could be requested by `window.open` or an external link like `<a target='_blank'>`.
+		
+		By default a new `BrowserWindow` will be created for the `url`.
+		
+		Calling `event.preventDefault()` will prevent Electron from automatically creating a new `BrowserWindow`. If you call `event.preventDefault()` and manually create a new `BrowserWindow` then you must set `event.newGuest` to reference the new `BrowserWindow` instance, failing to do so may result in unexpected behavior. For example:
+	**/
+	var new_window : electron.main.WebContentsEvent<Void -> Void> = "new-window";
+	/**
+		Emitted when a user or the page wants to start navigation. It can happen when the `window.location` object is changed or a user clicks a link in the page.
+		
+		This event will not emit when the navigation is started programmatically with APIs like `webContents.loadURL` and `webContents.back`.
+		
+		It is also not emitted for in-page navigations, such as clicking anchor links or updating the `window.location.hash`. Use `did-navigate-in-page` event for this purpose.
+		
+		Calling `event.preventDefault()` will prevent the navigation.
+	**/
+	var will_navigate : electron.main.WebContentsEvent<Void -> Void> = "will-navigate";
+	/**
+		Emitted when any frame (including main) starts navigating. `isInplace` will be `true` for in-page navigations.
+	**/
+	var did_start_navigation : electron.main.WebContentsEvent<Void -> Void> = "did-start-navigation";
+	/**
+		Emitted as a server side redirect occurs during navigation.  For example a 302 redirect.
+		
+		This event will be emitted after `did-start-navigation` and always before the `did-redirect-navigation` event for the same navigation.
+		
+		Calling `event.preventDefault()` will prevent the navigation (not just the redirect).
+	**/
+	var will_redirect : electron.main.WebContentsEvent<Void -> Void> = "will-redirect";
+	/**
+		Emitted after a server side redirect occurs during navigation.  For example a 302 redirect.
+		
+		This event cannot be prevented, if you want to prevent redirects you should checkout out the `will-redirect` event above.
+	**/
+	var did_redirect_navigation : electron.main.WebContentsEvent<Void -> Void> = "did-redirect-navigation";
+	/**
+		Emitted when a main frame navigation is done.
+		
+		This event is not emitted for in-page navigations, such as clicking anchor links or updating the `window.location.hash`. Use `did-navigate-in-page` event for this purpose.
+	**/
+	var did_navigate : electron.main.WebContentsEvent<Void -> Void> = "did-navigate";
+	/**
+		Emitted when any frame navigation is done.
+		
+		This event is not emitted for in-page navigations, such as clicking anchor links or updating the `window.location.hash`. Use `did-navigate-in-page` event for this purpose.
+	**/
+	var did_frame_navigate : electron.main.WebContentsEvent<Void -> Void> = "did-frame-navigate";
+	/**
+		Emitted when an in-page navigation happened in any frame.
+		
+		When in-page navigation happens, the page URL changes but does not cause navigation outside of the page. Examples of this occurring are when anchor links are clicked or when the DOM `hashchange` event is triggered.
+	**/
+	var did_navigate_in_page : electron.main.WebContentsEvent<Void -> Void> = "did-navigate-in-page";
+	/**
+		Emitted when a `beforeunload` event handler is attempting to cancel a page unload.
+		
+		Calling `event.preventDefault()` will ignore the `beforeunload` event handler and allow the page to be unloaded.
+	**/
+	var will_prevent_unload : electron.main.WebContentsEvent<Void -> Void> = "will-prevent-unload";
+	/**
+		Emitted when the renderer process crashes or is killed.
+		
+		**Deprecated:** This event is superceded by the `render-process-gone` event which contains more information about why the render process disappeared. It isn't always because it crashed.  The `killed` boolean can be replaced by checking `reason === 'killed'` when you switch to that event.
+	**/
+	var crashed : electron.main.WebContentsEvent<Void -> Void> = "crashed";
+	/**
+		Emitted when the renderer process unexpectedly disappears.  This is normally because it was crashed or killed.
+	**/
+	var render_process_gone : electron.main.WebContentsEvent<Void -> Void> = "render-process-gone";
+	/**
+		Emitted when the web page becomes unresponsive.
+	**/
+	var unresponsive : electron.main.WebContentsEvent<Void -> Void> = "unresponsive";
+	/**
+		Emitted when the unresponsive web page becomes responsive again.
+	**/
+	var responsive : electron.main.WebContentsEvent<Void -> Void> = "responsive";
+	/**
+		Emitted when a plugin process has crashed.
+	**/
+	var plugin_crashed : electron.main.WebContentsEvent<Void -> Void> = "plugin-crashed";
+	/**
+		Emitted when `webContents` is destroyed.
+	**/
+	var destroyed : electron.main.WebContentsEvent<Void -> Void> = "destroyed";
+	/**
+		Emitted before dispatching the `keydown` and `keyup` events in the page. Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events and the menu shortcuts.
+		
+		To only prevent the menu shortcuts, use `setIgnoreMenuShortcuts`:
+	**/
+	var before_input_event : electron.main.WebContentsEvent<Void -> Void> = "before-input-event";
+	/**
+		Emitted when the window enters a full-screen state triggered by HTML API.
+	**/
+	var enter_html_full_screen : electron.main.WebContentsEvent<Void -> Void> = "enter-html-full-screen";
+	/**
+		Emitted when the window leaves a full-screen state triggered by HTML API.
+	**/
+	var leave_html_full_screen : electron.main.WebContentsEvent<Void -> Void> = "leave-html-full-screen";
+	/**
+		Emitted when the user is requesting to change the zoom level using the mouse wheel.
+	**/
+	var zoom_changed : electron.main.WebContentsEvent<Void -> Void> = "zoom-changed";
+	/**
+		Emitted when DevTools is opened.
+	**/
+	var devtools_opened : electron.main.WebContentsEvent<Void -> Void> = "devtools-opened";
+	/**
+		Emitted when DevTools is closed.
+	**/
+	var devtools_closed : electron.main.WebContentsEvent<Void -> Void> = "devtools-closed";
+	/**
+		Emitted when DevTools is focused / opened.
+	**/
+	var devtools_focused : electron.main.WebContentsEvent<Void -> Void> = "devtools-focused";
+	/**
+		Emitted when failed to verify the `certificate` for `url`.
+		
+		The usage is the same with the `certificate-error` event of `app`.
+	**/
+	var certificate_error : electron.main.WebContentsEvent<Void -> Void> = "certificate-error";
+	/**
+		Emitted when a client certificate is requested.
+		
+		The usage is the same with the `select-client-certificate` event of `app`.
+	**/
+	var select_client_certificate : electron.main.WebContentsEvent<Void -> Void> = "select-client-certificate";
+	/**
+		Emitted when `webContents` wants to do basic auth.
+		
+		The usage is the same with the `login` event of `app`.
+	**/
+	var login : electron.main.WebContentsEvent<Void -> Void> = "login";
+	/**
+		Emitted when a result is available for [`webContents.findInPage`] request.
+	**/
+	var found_in_page : electron.main.WebContentsEvent<Void -> Void> = "found-in-page";
+	/**
+		Emitted when media starts playing.
+	**/
+	var media_started_playing : electron.main.WebContentsEvent<Void -> Void> = "media-started-playing";
+	/**
+		Emitted when media is paused or done playing.
+	**/
+	var media_paused : electron.main.WebContentsEvent<Void -> Void> = "media-paused";
+	/**
+		Emitted when a page's theme color changes. This is usually due to encountering a meta tag:
+	**/
+	var did_change_theme_color : electron.main.WebContentsEvent<Void -> Void> = "did-change-theme-color";
+	/**
+		Emitted when mouse moves over a link or the keyboard moves the focus to a link.
+	**/
+	var update_target_url : electron.main.WebContentsEvent<Void -> Void> = "update-target-url";
+	/**
+		Emitted when the cursor's type changes. The `type` parameter can be `default`, `crosshair`, `pointer`, `text`, `wait`, `help`, `e-resize`, `n-resize`, `ne-resize`, `nw-resize`, `s-resize`, `se-resize`, `sw-resize`, `w-resize`, `ns-resize`, `ew-resize`, `nesw-resize`, `nwse-resize`, `col-resize`, `row-resize`, `m-panning`, `e-panning`, `n-panning`, `ne-panning`, `nw-panning`, `s-panning`, `se-panning`, `sw-panning`, `w-panning`, `move`, `vertical-text`, `cell`, `context-menu`, `alias`, `progress`, `nodrop`, `copy`, `none`, `not-allowed`, `zoom-in`, `zoom-out`, `grab`, `grabbing` or `custom`.
+		
+		If the `type` parameter is `custom`, the `image` parameter will hold the custom cursor image in a `NativeImage`, and `scale`, `size` and `hotspot` will hold additional information about the custom cursor.
+	**/
+	var cursor_changed : electron.main.WebContentsEvent<Void -> Void> = "cursor-changed";
+	/**
+		Emitted when there is a new context menu that needs to be handled.
+	**/
+	var context_menu : electron.main.WebContentsEvent<Void -> Void> = "context-menu";
+	/**
+		Emitted when bluetooth device needs to be selected on call to `navigator.bluetooth.requestDevice`. To use `navigator.bluetooth` api `webBluetooth` should be enabled. If `event.preventDefault` is not called, first available device will be selected. `callback` should be called with `deviceId` to be selected, passing empty string to `callback` will cancel the request.
+	**/
+	var select_bluetooth_device : electron.main.WebContentsEvent<Void -> Void> = "select-bluetooth-device";
+	/**
+		Emitted when a new frame is generated. Only the dirty area is passed in the buffer.
+	**/
+	var paint : electron.main.WebContentsEvent<Void -> Void> = "paint";
+	/**
+		Emitted when the devtools window instructs the webContents to reload
+	**/
+	var devtools_reload_page : electron.main.WebContentsEvent<Void -> Void> = "devtools-reload-page";
+	/**
+		Emitted when a `<webview>`'s web contents is being attached to this web contents. Calling `event.preventDefault()` will destroy the guest page.
+		
+		This event can be used to configure `webPreferences` for the `webContents` of a `<webview>` before it's loaded, and provides the ability to set settings that can't be set via `<webview>` attributes.
+		
+		**Note:** The specified `preload` script option will appear as `preloadURL` (not `preload`) in the `webPreferences` object emitted with this event.
+	**/
+	var will_attach_webview : electron.main.WebContentsEvent<Void -> Void> = "will-attach-webview";
+	/**
+		Emitted when a `<webview>` has been attached to this web contents.
+	**/
+	var did_attach_webview : electron.main.WebContentsEvent<Void -> Void> = "did-attach-webview";
+	/**
+		Emitted when the associated window logs a console message.
+	**/
+	var console_message : electron.main.WebContentsEvent<Void -> Void> = "console-message";
+	/**
+		Emitted when the preload script `preloadPath` throws an unhandled exception `error`.
+	**/
+	var preload_error : electron.main.WebContentsEvent<Void -> Void> = "preload-error";
+	/**
+		Emitted when the renderer process sends an asynchronous message via `ipcRenderer.send()`.
+	**/
+	var ipc_message : electron.main.WebContentsEvent<Void -> Void> = "ipc-message";
+	/**
+		Emitted when the renderer process sends a synchronous message via `ipcRenderer.sendSync()`.
+	**/
+	var ipc_message_sync : electron.main.WebContentsEvent<Void -> Void> = "ipc-message-sync";
+	/**
+		Emitted when `desktopCapturer.getSources()` is called in the renderer process. Calling `event.preventDefault()` will make it return empty sources.
+	**/
+	var desktop_capturer_get_sources : electron.main.WebContentsEvent<Void -> Void> = "desktop-capturer-get-sources";
+	/**
+		Emitted when `remote.require()` is called in the renderer process. Calling `event.preventDefault()` will prevent the module from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_require : electron.main.WebContentsEvent<Void -> Void> = "remote-require";
+	/**
+		Emitted when `remote.getGlobal()` is called in the renderer process. Calling `event.preventDefault()` will prevent the global from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_global : electron.main.WebContentsEvent<Void -> Void> = "remote-get-global";
+	/**
+		Emitted when `remote.getBuiltin()` is called in the renderer process. Calling `event.preventDefault()` will prevent the module from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_builtin : electron.main.WebContentsEvent<Void -> Void> = "remote-get-builtin";
+	/**
+		Emitted when `remote.getCurrentWindow()` is called in the renderer process. Calling `event.preventDefault()` will prevent the object from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_current_window : electron.main.WebContentsEvent<Void -> Void> = "remote-get-current-window";
+	/**
+		Emitted when `remote.getCurrentWebContents()` is called in the renderer process. Calling `event.preventDefault()` will prevent the object from being returned. Custom value can be returned by setting `event.returnValue`.
+	**/
+	var remote_get_current_web_contents : electron.main.WebContentsEvent<Void -> Void> = "remote-get-current-web-contents";
+}

--- a/src/electron/remote/WebRequest.hx
+++ b/src/electron/remote/WebRequest.hx
@@ -1,0 +1,75 @@
+package electron.remote;
+/**
+	@see https://electronjs.org/docs/api/web-request
+**/
+@:jsRequire("electron", "remote.WebRequest") extern class WebRequest extends js.node.events.EventEmitter<electron.main.WebRequest> {
+	/**
+		The `listener` will be called with `listener(details, callback)` when a request is about to occur.
+		
+		The `uploadData` is an array of `UploadData` objects.
+		
+		The `callback` has to be called with an `response` object.
+		
+		Some examples of valid `urls`:
+	**/
+	function onBeforeRequest(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details, callback)` before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is made to the server, but before any http data is sent.
+		
+		The `callback` has to be called with a `response` object.
+	**/
+	function onBeforeSendHeaders(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details)` just before a request is going to be sent to the server, modifications of previous `onBeforeSendHeaders` response are visible by the time this listener is fired.
+	**/
+	function onSendHeaders(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details, callback)` when HTTP response headers of a request have been received.
+		
+		The `callback` has to be called with a `response` object.
+	**/
+	function onHeadersReceived(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details)` when first byte of the response body is received. For HTTP requests, this means that the status line and response headers are available.
+	**/
+	function onResponseStarted(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details)` when a server initiated redirect is about to occur.
+	**/
+	function onBeforeRedirect(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details)` when a request is completed.
+	**/
+	function onCompleted(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+	/**
+		The `listener` will be called with `listener(details)` when an error occurs.
+	**/
+	function onErrorOccurred(?filter:{ /**
+		Array of URL patterns that will be used to filter out the requests that do not match the URL patterns.
+	**/
+	var urls : Array<String>; }, listener:haxe.extern.EitherType<Dynamic, Dynamic>):Void;
+}
+@:enum abstract WebRequestEvent<T:(haxe.Constraints.Function)>(js.node.events.EventEmitter.Event<T>) to js.node.events.EventEmitter.Event<T> {
+
+}


### PR DESCRIPTION
Fixes https://github.com/tong/hxelectron/issues/49 in a rather hacky way. It is done by copying the generated .hx files to the remote folder and performing some string replacement.