### PR TITLE
Fixed missing @:optional in Structures

### DIFF
--- a/ElectronAPI.hx
+++ b/ElectronAPI.hx
@@ -414,7 +414,10 @@ private class Gen {
 	}
 
 	function createVarField( p : Property, ?access : Array<Access> ) : Field {
-		return createField( p.name, FVar( getComplexType( p.type, p.collection, p.properties ), null ), access, null, p.description );
+		var meta : Metadata = null;
+		if( p.required!=null && !p.required )
+			meta = [{ name:":optional", pos:null }];
+		return createField( p.name, FVar( getComplexType( p.type, p.collection, p.properties ), null ), access, meta, p.description );
 	}
 
 	function createFunField( m : Method, ?access : Array<Access> ) : Field {
@@ -646,8 +649,8 @@ typedef Property = {
 	type : String,
 	collection: Bool,
 	?description : String,
-	?properties : Array<Property>
-	// TODO: ?required
+	?properties : Array<Property>,
+	?required : Bool,
 	// TODO: ?possibleValues
 	// TODO: ?additionalTags : Array<String>
 }


### PR DESCRIPTION
This commit fixes the generation of all typedefs that didn't have an `@:optional` meta, while their `required` flag was false